### PR TITLE
Feat/#8 회원가입 연관NO.2,3,4,5,6 API 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,15 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 
+
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.apache.httpcomponents:httpclient:4.5.13'
+	implementation 'org.json:json:20210307'
+
+
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'

--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,17 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'com.slack.api:slack-api-client:1.30.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0' // 최신 버전으로 업데이트
+	implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0'
+	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.0'
+
+
+
 	implementation group: 'org.postgresql', name: 'postgresql', version: '42.7.3'
 	implementation("software.amazon.awssdk:bom:2.21.0")
 	implementation("software.amazon.awssdk:s3:2.21.0")

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
 	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0' // 최신 버전으로 업데이트
 	implementation 'com.fasterxml.jackson.core:jackson-core:2.14.0'
 	implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.0'

--- a/src/main/java/sopt/univoice/domain/affiliation/controller/AffiliationController.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/controller/AffiliationController.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.affiliation.controller;
+
+public class AffiliationController {
+}

--- a/src/main/java/sopt/univoice/domain/affiliation/entity/Affiliation.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/entity/Affiliation.java
@@ -36,6 +36,13 @@ public class Affiliation extends BaseTimeEntity {
     private List<Member> members;
 
 
+
+
+
+
+
+
+
     // 새로운 생성자 추가
     @Builder
     public Affiliation(Role role) {

--- a/src/main/java/sopt/univoice/domain/affiliation/entity/Affiliation.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/entity/Affiliation.java
@@ -1,4 +1,40 @@
 package sopt.univoice.domain.affiliation.entity;
 
-public class Affiliation {
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.univoice.domain.user.entity.Member;
+import sopt.univoice.infra.persistence.BaseTimeEntity;
+
+import java.util.List;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Affiliation extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String role;
+
+    private String affiliationName;
+
+    private String affiliation;
+
+    private String affiliationCardImage;
+
+    private String affiliationLogoImage;
+
+
+    @OneToMany(mappedBy = "affiliation", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Member> members;
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/affiliation/entity/Affiliation.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/entity/Affiliation.java
@@ -3,6 +3,7 @@ package sopt.univoice.domain.affiliation.entity;
 
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.user.entity.Member;
@@ -19,7 +20,8 @@ public class Affiliation extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String role;
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     private String affiliationName;
 
@@ -34,7 +36,14 @@ public class Affiliation extends BaseTimeEntity {
     private List<Member> members;
 
 
+    // 새로운 생성자 추가
+    @Builder
+    public Affiliation(Role role) {
+        this.role = role;
+    }
 
-
+    public static Affiliation createDefault() {
+        return Affiliation.builder().role(Role.UNUSER).build();
+    }
 
 }

--- a/src/main/java/sopt/univoice/domain/affiliation/entity/Role.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/entity/Role.java
@@ -1,0 +1,5 @@
+package sopt.univoice.domain.affiliation.entity;
+
+public enum Role {
+    UNUSER, USER, ADMIN
+}

--- a/src/main/java/sopt/univoice/domain/affiliation/entity/Role.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/entity/Role.java
@@ -1,5 +1,5 @@
 package sopt.univoice.domain.affiliation.entity;
 
 public enum Role {
-    UNUSER, USER, ADMIN
+    UNUSER, APPROVEUSER, APPROVEADMIN
 }

--- a/src/main/java/sopt/univoice/domain/affiliation/repository/AffiliationRepository.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/repository/AffiliationRepository.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.affiliation.repository;
+
+public interface AffiliationRepository {
+}

--- a/src/main/java/sopt/univoice/domain/affiliation/repository/AffiliationRepository.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/repository/AffiliationRepository.java
@@ -1,4 +1,8 @@
 package sopt.univoice.domain.affiliation.repository;
 
-public interface AffiliationRepository {
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.affiliation.entity.Affiliation;
+
+public interface AffiliationRepository extends JpaRepository<Affiliation, Integer> {
 }

--- a/src/main/java/sopt/univoice/domain/affiliation/service/AffiliationService.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/service/AffiliationService.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.affiliation.service;
+
+public class AffiliationService {
+}

--- a/src/main/java/sopt/univoice/domain/auth/PrincipalHandler.java
+++ b/src/main/java/sopt/univoice/domain/auth/PrincipalHandler.java
@@ -14,13 +14,13 @@ public class PrincipalHandler {
     public Long getUserIdFromPrincipal() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         isPrincipalNull(principal);
+        System.out.println("Principal: " + principal);
         return Long.valueOf(principal.toString());
     }
 
-    public void isPrincipalNull(
-            final Object principal
-    ) {
+    public void isPrincipalNull(final Object principal) {
         if (principal.toString().equals(ANONYMOUS_USER)) {
+            System.out.println("Principal is anonymous");
             throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
         }
     }

--- a/src/main/java/sopt/univoice/domain/auth/PrincipalHandler.java
+++ b/src/main/java/sopt/univoice/domain/auth/PrincipalHandler.java
@@ -1,0 +1,27 @@
+package sopt.univoice.domain.auth;
+
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import sopt.univoice.infra.common.exception.UnauthorizedException;
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+
+@Component
+public class PrincipalHandler {
+
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
+    public Long getUserIdFromPrincipal() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        isPrincipalNull(principal);
+        return Long.valueOf(principal.toString());
+    }
+
+    public void isPrincipalNull(
+            final Object principal
+    ) {
+        if (principal.toString().equals(ANONYMOUS_USER)) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+    }
+}

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
-                    auth.requestMatchers("/api/v1/notice").hasAnyAuthority("APPROVEUSER", "APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/notice/**").hasAnyAuthority("APPROVEUSER", "APPROVEADMIN");
                     auth.requestMatchers("/api/v1/notice/create").hasAuthority("APPROVEADMIN");
                     auth.anyRequest().authenticated();
                 })

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -1,0 +1,59 @@
+package sopt.univoice.domain.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import sopt.univoice.domain.auth.filter.CustomAccessDeniedHandler;
+import sopt.univoice.domain.auth.filter.CustomJwtAuthenticationEntryPoint;
+import sopt.univoice.domain.auth.filter.JwtAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    private static final String[] AUTH_WHITE_LIST = {
+            "/api/v1/auth/signin",
+            "/api/v1/universityData/university",
+            "/api/v1/universityData/department",
+            "/api/v1/auth/check-email",
+            "/api/v1/auth/signup",
+            "/api/v1/auth/accecpt"
+    };
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                });
+
+        http.authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                    auth.requestMatchers("/api/v1/posts").hasAnyRole("APPROVEUSER", "APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/posts/**").hasRole("APPROVEADMIN");
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
                     auth.requestMatchers("/api/v1/notice").hasAnyAuthority("APPROVEUSER", "APPROVEADMIN");
-                    auth.requestMatchers("/api/v1/notice/**").hasAuthority("APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/notice/create").hasAuthority("APPROVEADMIN");
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
 
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        System.out.println("aaaaa");
         http.csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .requestCache(RequestCacheConfigurer::disable)
@@ -47,15 +48,15 @@ public class SecurityConfig {
                     exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
                     exception.accessDeniedHandler(customAccessDeniedHandler);
                 });
+        System.out.println("Bbb");
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
-                    auth.requestMatchers("/api/v1/notice").hasAnyRole("APPROVEUSER", "APPROVEADMIN");
-                    auth.requestMatchers("/api/v1/notice/**").hasRole("APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/notice").hasAnyAuthority("APPROVEUSER", "APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/notice/**").hasAuthority("APPROVEADMIN");
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
         return http.build();
     }
 }

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -29,7 +29,8 @@ public class SecurityConfig {
             "/api/v1/universityData/department",
             "/api/v1/auth/check-email",
             "/api/v1/auth/signup",
-            "/api/v1/auth/accecpt"
+            "/api/v1/auth/accecpt",
+            "api/v1/auth/"
     };
 
     @Bean

--- a/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
+++ b/src/main/java/sopt/univoice/domain/auth/SecurityConfig.java
@@ -50,8 +50,8 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
-                    auth.requestMatchers("/api/v1/posts").hasAnyRole("APPROVEUSER", "APPROVEADMIN");
-                    auth.requestMatchers("/api/v1/posts/**").hasRole("APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/notice").hasAnyRole("APPROVEUSER", "APPROVEADMIN");
+                    auth.requestMatchers("/api/v1/notice/**").hasRole("APPROVEADMIN");
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/sopt/univoice/domain/auth/UserAuthentication.java
+++ b/src/main/java/sopt/univoice/domain/auth/UserAuthentication.java
@@ -1,0 +1,17 @@
+package sopt.univoice.domain.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static UserAuthentication createUserAuthentication(Long userId) {
+        return new UserAuthentication(userId, null, null);
+    }
+}

--- a/src/main/java/sopt/univoice/domain/auth/UserAuthentication.java
+++ b/src/main/java/sopt/univoice/domain/auth/UserAuthentication.java
@@ -11,7 +11,8 @@ public class UserAuthentication extends UsernamePasswordAuthenticationToken {
         super(principal, credentials, authorities);
     }
 
-    public static UserAuthentication createUserAuthentication(Long userId) {
-        return new UserAuthentication(userId, null, null);
+    public static UserAuthentication createUserAuthentication(Long userId, Collection<? extends GrantedAuthority> authorities) {
+        return new UserAuthentication(userId, null, authorities);
     }
 }
+

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import sopt.univoice.infra.common.exception.message.BusinessException;
 import sopt.univoice.infra.common.exception.message.ErrorMessage;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -40,6 +41,22 @@ public class AuthController {
                 .body(SuccessStatusResponse.of(SuccessMessage.SIGNUP_SUCCESS, null));
     }
 
+
+
+
+    @PostMapping("/slack/actions")
+    public void handleSlackActions(@RequestBody Map<String, Object> payload) {
+        List<Map<String, Object>> actions = (List<Map<String, Object>>) payload.get("actions");
+        String actionId = (String) actions.get(0).get("action_id");
+
+        if ("approve_action".equals(actionId)) {
+            // 승인 처리 로직
+            System.out.println("승인 버튼 클릭됨");
+        } else if ("reject_action".equals(actionId)) {
+            // 거절 처리 로직
+            System.out.println("거절 버튼 클릭됨");
+        }
+    }
 
 
 

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -33,21 +33,12 @@ public class AuthController {
         }
     }
 
-
     @PostMapping("/signup")
     public ResponseEntity<SuccessStatusResponse<Void>> signUp(@ModelAttribute MemberCreateRequest memberCreateRequest) {
-
-
-
-
-
+        authService.signUp(memberCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessStatusResponse.of(SuccessMessage.SIGNUP_SUCCESS, null));
     }
-
-
-
-
-
-
 
 
 

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -1,4 +1,43 @@
 package sopt.univoice.domain.auth.controller;
 
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sopt.univoice.domain.auth.dto.CheckEmailRequest;
+import sopt.univoice.domain.auth.service.AuthService;
+import sopt.univoice.domain.universityData.dto.UniversityNameRequest;
+import sopt.univoice.infra.common.dto.SuccessMessage;
+import sopt.univoice.infra.common.dto.SuccessStatusResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final AuthService authService;
+    @PostMapping("/check-email")
+    public ResponseEntity<SuccessStatusResponse<Void>> checkEmail(@RequestBody CheckEmailRequest checkEmailRequest) {
+        boolean isDuplicate = authService.isDuplicateEmail(checkEmailRequest);
+        if (isDuplicate) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(SuccessStatusResponse.of(SuccessMessage.EMAIL_DUPLICATE));
+        } else {
+            return ResponseEntity.status(HttpStatus.OK)
+                    .body(SuccessStatusResponse.of(SuccessMessage.EMAIL_AVAILABLE));
+        }
+    }
+
+
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -51,6 +51,9 @@ public class AuthController {
 
     @PostMapping("/signup")
     public ResponseEntity<SuccessStatusResponse<Void>> signUp(@ModelAttribute MemberCreateRequest memberCreateRequest) {
+        System.out.println(memberCreateRequest.toString());
+
+
         authService.signUp(memberCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.SIGNUP_SUCCESS, null));

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
+import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.universityData.dto.UniversityNameRequest;
 import sopt.univoice.infra.common.dto.SuccessMessage;
@@ -30,6 +31,16 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.OK)
                     .body(SuccessStatusResponse.of(SuccessMessage.EMAIL_AVAILABLE));
         }
+    }
+
+
+    @PostMapping("/signup")
+    public ResponseEntity<SuccessStatusResponse<Void>> signUp(@ModelAttribute MemberCreateRequest memberCreateRequest) {
+
+
+
+
+
     }
 
 

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -10,6 +10,8 @@ import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.universityData.dto.UniversityNameRequest;
 import sopt.univoice.infra.common.dto.SuccessMessage;
 import sopt.univoice.infra.common.dto.SuccessStatusResponse;
+import sopt.univoice.infra.common.exception.message.BusinessException;
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
 
 import java.util.List;
 
@@ -23,8 +25,7 @@ public class AuthController {
     public ResponseEntity<SuccessStatusResponse<Void>> checkEmail(@RequestBody CheckEmailRequest checkEmailRequest) {
         boolean isDuplicate = authService.isDuplicateEmail(checkEmailRequest);
         if (isDuplicate) {
-            return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(SuccessStatusResponse.of(SuccessMessage.EMAIL_DUPLICATE));
+            throw new BusinessException(ErrorMessage.EMAIL_DUPLICATE);
         } else {
             return ResponseEntity.status(HttpStatus.OK)
                     .body(SuccessStatusResponse.of(SuccessMessage.EMAIL_AVAILABLE));

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
+import sopt.univoice.domain.auth.dto.MemberSignInRequest;
+import sopt.univoice.domain.auth.dto.UserLoginResponse;
 import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.universityData.dto.UniversityNameRequest;
 import sopt.univoice.infra.common.dto.SuccessMessage;
@@ -34,6 +36,19 @@ public class AuthController {
         }
     }
 
+
+    @PostMapping("/signin")
+    public ResponseEntity<UserLoginResponse> signIn(@RequestBody MemberSignInRequest memberSignInRequest) {
+
+        UserLoginResponse userLoginResponse = authService.logineMember(memberSignInRequest);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .header("Location", userLoginResponse.userId())
+                .body(
+                        userLoginResponse
+                );
+    }
+
     @PostMapping("/signup")
     public ResponseEntity<SuccessStatusResponse<Void>> signUp(@ModelAttribute MemberCreateRequest memberCreateRequest) {
         authService.signUp(memberCreateRequest);
@@ -57,6 +72,14 @@ public class AuthController {
             System.out.println("거절 버튼 클릭됨");
         }
     }
+
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
+++ b/src/main/java/sopt/univoice/domain/auth/controller/AuthController.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.auth.controller;
+
+public class AuthController {
+}

--- a/src/main/java/sopt/univoice/domain/auth/dto/CheckEmailRequest.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/CheckEmailRequest.java
@@ -1,0 +1,10 @@
+package sopt.univoice.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CheckEmailRequest {
+    private String email;
+}

--- a/src/main/java/sopt/univoice/domain/auth/dto/CheckEmailRequest.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/CheckEmailRequest.java
@@ -3,6 +3,7 @@ package sopt.univoice.domain.auth.dto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
 @Getter
 @NoArgsConstructor
 public class CheckEmailRequest {

--- a/src/main/java/sopt/univoice/domain/auth/dto/MemberCreateRequest.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/MemberCreateRequest.java
@@ -1,0 +1,29 @@
+package sopt.univoice.domain.auth.dto;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@NoArgsConstructor
+public class MemberCreateRequest{
+
+    private  Long admissionNumber;
+
+    private String name;
+
+    private String studentNumber;
+
+    private String email;
+
+    private String password;
+
+    MultipartFile studentCardImage;
+
+    private String  universityName;
+
+    private String departmentName;
+
+
+}

--- a/src/main/java/sopt/univoice/domain/auth/dto/MemberCreateRequest.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/MemberCreateRequest.java
@@ -1,15 +1,13 @@
 package sopt.univoice.domain.auth.dto;
 
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.web.multipart.MultipartFile;
 @Setter
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class MemberCreateRequest{
 
     private  Long admissionNumber;
@@ -27,6 +25,8 @@ public class MemberCreateRequest{
     private String  universityName;
 
     private String departmentName;
+
+
 
 
 }

--- a/src/main/java/sopt/univoice/domain/auth/dto/MemberCreateRequest.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/MemberCreateRequest.java
@@ -1,12 +1,15 @@
 package sopt.univoice.domain.auth.dto;
 
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
-
+@Setter
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 public class MemberCreateRequest{
 
     private  Long admissionNumber;

--- a/src/main/java/sopt/univoice/domain/auth/dto/MemberSignInRequest.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/MemberSignInRequest.java
@@ -1,0 +1,11 @@
+package sopt.univoice.domain.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberSignInRequest {
+    private String email;
+    private String password;
+}

--- a/src/main/java/sopt/univoice/domain/auth/dto/UserLoginResponse.java
+++ b/src/main/java/sopt/univoice/domain/auth/dto/UserLoginResponse.java
@@ -1,0 +1,14 @@
+package sopt.univoice.domain.auth.dto;
+
+public record UserLoginResponse(
+        String accessToken,
+        String userId
+) {
+
+    public static UserLoginResponse of(
+            String accessToken,
+            String userId
+    ) {
+        return new UserLoginResponse(accessToken, userId);
+    }
+}

--- a/src/main/java/sopt/univoice/domain/auth/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/sopt/univoice/domain/auth/filter/CustomAccessDeniedHandler.java
@@ -5,13 +5,19 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.access.AccessDeniedException; // 올바른 import 경로
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 import java.io.IOException;
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        System.out.println("Access denied for request: " + request.getRequestURI());
+        System.out.println("Reason: " + accessDeniedException.getMessage());
+        System.out.println("User authorities:"+ SecurityContextHolder.getContext().getAuthentication().getAuthorities());
+
         setResponse(response);
     }
 

--- a/src/main/java/sopt/univoice/domain/auth/filter/CustomAccessDeniedHandler.java
+++ b/src/main/java/sopt/univoice/domain/auth/filter/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package sopt.univoice.domain.auth.filter;
+
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException; // 올바른 import 경로
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}
+

--- a/src/main/java/sopt/univoice/domain/auth/filter/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/sopt/univoice/domain/auth/filter/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package sopt.univoice.domain.auth.filter;
+
+
+
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import sopt.univoice.infra.common.dto.ErrorResponse;
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+                .write(objectMapper.writeValueAsString(
+                        ErrorResponse.of(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION.getStatus(),
+                                ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION.getMessage())));
+    }
+}

--- a/src/main/java/sopt/univoice/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/univoice/domain/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,71 @@
+package sopt.univoice.domain.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+import sopt.univoice.domain.auth.UserAuthentication;
+import sopt.univoice.infra.common.exception.UnauthorizedException;
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+import sopt.univoice.infra.common.jwt.JwtTokenProvider;
+import sopt.univoice.infra.common.jwt.JwtValidationType;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private static final Set<String> WHITE_LIST_PATHS = new HashSet<>();
+
+    static {
+        WHITE_LIST_PATHS.add("/api/v1/auth/signin");
+        WHITE_LIST_PATHS.add("/api/v1/universityData/university");
+        WHITE_LIST_PATHS.add("/api/v1/universityData/department");
+        WHITE_LIST_PATHS.add("/api/v1/auth/check-email");
+        WHITE_LIST_PATHS.add("/api/v1/auth/signup");
+        WHITE_LIST_PATHS.add("/api/v1/auth/accecpt");
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        // 화이트리스트 경로인 경우 필터를 통과시킴
+        if (WHITE_LIST_PATHS.contains(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            final String token = getJwtFromRequest(request);
+            if (token != null && jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
+                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+                UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/sopt/univoice/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/univoice/domain/auth/filter/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import sopt.univoice.infra.common.jwt.JwtTokenProvider;
 import sopt.univoice.infra.common.jwt.JwtValidationType;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -49,9 +50,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             final String token = getJwtFromRequest(request);
-            if (token != null && jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
-                Long memberId = jwtTokenProvider.getUserFromJwt(token);
-                UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
+            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
+                Long userId = jwtTokenProvider.getUserFromJwt(token);
+                Collection authorities = jwtTokenProvider.getAuthoritiesFromJwt(token);
+
+                UserAuthentication authentication = new UserAuthentication(userId, null, authorities);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
@@ -60,6 +63,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         filterChain.doFilter(request, response);
     }
+
+
+
+
+
+
 
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");

--- a/src/main/java/sopt/univoice/domain/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/sopt/univoice/domain/auth/filter/JwtAuthenticationFilter.java
@@ -43,6 +43,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         // 화이트리스트 경로인 경우 필터를 통과시킴
+        System.out.println("Request URI(filter): " + request.getRequestURI());
         if (WHITE_LIST_PATHS.contains(request.getRequestURI())) {
             filterChain.doFilter(request, response);
             return;
@@ -53,28 +54,34 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token) == JwtValidationType.VALID_JWT) {
                 Long userId = jwtTokenProvider.getUserFromJwt(token);
                 Collection authorities = jwtTokenProvider.getAuthoritiesFromJwt(token);
+                System.out.println("Authenticated User ID(filter): " + userId);
+                System.out.println("Authorities(filter): " + authorities);
 
                 UserAuthentication authentication = new UserAuthentication(userId, null, authorities);
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+                System.out.println("User authenticated successfully with roles: (filter)" + authorities);
+            } else {
+                System.out.println("Token is not valid or not present");
             }
         } catch (Exception exception) {
+            System.out.println("Exception during token validation: " + exception.getMessage());
             throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
         }
+        System.out.println("ㅇㅇㅇㅇㅇㅇㅇㅇㅇㅇ");
         filterChain.doFilter(request, response);
+        System.out.println("ㅇㅇㅇㅇ");
     }
-
-
-
-
-
 
 
     private String getJwtFromRequest(HttpServletRequest request) {
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-            return bearerToken.substring("Bearer ".length());
+            String token = bearerToken.substring("Bearer ".length());
+            System.out.println("Extracted JWT Token(filter): " + token);
+            return token;
         }
+        System.out.println("No JWT Token found in request");
         return null;
     }
 }

--- a/src/main/java/sopt/univoice/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/sopt/univoice/domain/auth/repository/AuthRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
 import sopt.univoice.domain.user.entity.Member;
 
+import java.util.Optional;
+
 public interface AuthRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/sopt/univoice/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/sopt/univoice/domain/auth/repository/AuthRepository.java
@@ -4,9 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
 import sopt.univoice.domain.user.entity.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AuthRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);
+
+    List<Member> findByUniversityName(String universityName);
 }

--- a/src/main/java/sopt/univoice/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/sopt/univoice/domain/auth/repository/AuthRepository.java
@@ -1,0 +1,9 @@
+package sopt.univoice.domain.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.auth.dto.CheckEmailRequest;
+import sopt.univoice.domain.user.entity.Member;
+
+public interface AuthRepository extends JpaRepository<Member, Long> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/sopt/univoice/domain/auth/repository/AuthRepositroy.java
+++ b/src/main/java/sopt/univoice/domain/auth/repository/AuthRepositroy.java
@@ -1,4 +1,0 @@
-package sopt.univoice.domain.auth.repository;
-
-public interface AuthRepositroy {
-}

--- a/src/main/java/sopt/univoice/domain/auth/repository/AuthRepositroy.java
+++ b/src/main/java/sopt/univoice/domain/auth/repository/AuthRepositroy.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.auth.repository;
+
+public interface AuthRepositroy {
+}

--- a/src/main/java/sopt/univoice/domain/auth/repository/CollegeDepartmentRepository.java
+++ b/src/main/java/sopt/univoice/domain/auth/repository/CollegeDepartmentRepository.java
@@ -1,0 +1,11 @@
+package sopt.univoice.domain.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.universityData.entity.CollegeDepartment;
+
+
+
+public interface CollegeDepartmentRepository extends JpaRepository<CollegeDepartment, Long> {
+    // JpaRepository already provides findById method, no need to redefine it
+}
+

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -166,11 +166,7 @@ public class AuthService {
             noticeViewRepository.save(noticeView);
         }
 
-
-
     }
-
-
 
     @Transactional
     public UserLoginResponse logineMember(
@@ -191,6 +187,9 @@ public class AuthService {
 
         return UserLoginResponse.of(accessToken, memberId.toString());
     }
+
+
+
 
 
 

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -19,6 +19,10 @@ import sopt.univoice.domain.auth.dto.MemberSignInRequest;
 import sopt.univoice.domain.auth.dto.UserLoginResponse;
 import sopt.univoice.domain.auth.repository.AuthRepository;
 import sopt.univoice.domain.auth.repository.CollegeDepartmentRepository;
+import sopt.univoice.domain.notice.entity.Notice;
+import sopt.univoice.domain.notice.entity.NoticeView;
+import sopt.univoice.domain.notice.repository.NoticeRepository;
+import sopt.univoice.domain.notice.repository.NoticeViewRepository;
 import sopt.univoice.domain.universityData.entity.CollegeDepartment;
 import sopt.univoice.domain.universityData.entity.Department;
 import sopt.univoice.domain.universityData.repository.DepartmentRepository;
@@ -56,6 +60,8 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final ObjectMapper objectMapper;
+    private final NoticeRepository noticeRepository;
+    private final NoticeViewRepository noticeViewRepository;
 
     public boolean isDuplicateEmail(CheckEmailRequest checkEmailRequest) {
         return authRepository.existsByEmail(checkEmailRequest.getEmail());
@@ -148,6 +154,20 @@ public class AuthService {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+
+// NoticeView 엔티티 생성 및 저장
+        List<Notice> notices = noticeRepository.findAllByMemberUniversityName(member.getUniversityName());
+        for (Notice notice : notices) {
+            NoticeView noticeView = NoticeView.builder()
+                    .notice(notice)
+                    .member(member)
+                    .readAt(false)
+                    .build();
+            noticeViewRepository.save(noticeView);
+        }
+
+
+
     }
 
 

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.Payload;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +34,7 @@ import com.slack.api.model.block.element.BlockElements;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static com.slack.api.model.block.composition.BlockCompositions.plainText;
@@ -150,8 +152,6 @@ public class AuthService {
 
 
 
-
-
     @Transactional
     public UserLoginResponse logineMember(
             MemberSignInRequest memberSignInRequest
@@ -164,8 +164,9 @@ public class AuthService {
         }
 
         Long memberId = member.getId();
+        Collection<? extends GrantedAuthority> authorities = member.getAuthorities(); // 역할 정보 가져오기
         String accessToken = jwtTokenProvider.issueAccessToken(
-                UserAuthentication.createUserAuthentication(memberId)
+                UserAuthentication.createUserAuthentication(memberId, authorities)
         );
 
         return UserLoginResponse.of(accessToken, memberId.toString());

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -1,4 +1,21 @@
 package sopt.univoice.domain.auth.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sopt.univoice.domain.auth.dto.CheckEmailRequest;
+import sopt.univoice.domain.auth.repository.AuthRepository;
+
+@Service
+@RequiredArgsConstructor
 public class AuthService {
+
+
+    private final AuthRepository authRepository;
+
+    public boolean isDuplicateEmail(CheckEmailRequest checkEmailRequest) {
+        return authRepository.existsByEmail(checkEmailRequest.getEmail());
+    }
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -2,9 +2,14 @@ package sopt.univoice.domain.auth.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
+import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.repository.AuthRepository;
+import sopt.univoice.domain.user.entity.Member;
 import sopt.univoice.infra.external.S3Service;
+
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,29 @@ public class AuthService {
         return authRepository.existsByEmail(checkEmailRequest.getEmail());
     }
 
+
+    @Transactional
+    public void signUp(MemberCreateRequest memberCreateRequest) {
+        String imageUrl = null;
+        try {
+            imageUrl = s3Service.uploadImage("student-card-images/", memberCreateRequest.getStudentCardImage());
+        } catch (IOException e) {
+            throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
+        }
+
+        Member member = Member.builder()
+                .admissionNumber(memberCreateRequest.getAdmissionNumber())
+                .name(memberCreateRequest.getName())
+                .studentNumber(memberCreateRequest.getStudentNumber())
+                .email(memberCreateRequest.getEmail())
+                .password(memberCreateRequest.getPassword())
+                .studentCardImage(imageUrl)
+                .universityName(memberCreateRequest.getUniversityName())
+                .departmentName(memberCreateRequest.getDepartmentName())
+                .build();
+
+        authRepository.save(member);
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
 import sopt.univoice.domain.auth.repository.AuthRepository;
+import sopt.univoice.infra.external.S3Service;
 
 @Service
 @RequiredArgsConstructor
@@ -11,6 +12,7 @@ public class AuthService {
 
 
     private final AuthRepository authRepository;
+    private final S3Service s3Service;
 
     public boolean isDuplicateEmail(CheckEmailRequest checkEmailRequest) {
         return authRepository.existsByEmail(checkEmailRequest.getEmail());

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -72,7 +72,7 @@ public class AuthService {
         CollegeDepartment collegeDepartment = collegeDepartmentRepository.findById(department.getCollegeDepartment().getId())
                 .orElseThrow(() -> new RuntimeException("해당 단과대학이 존재하지 않습니다."));
 
-        Affiliation affiliation = new Affiliation();
+        Affiliation affiliation = Affiliation.createDefault();
         affiliationRepository.save(affiliation);
 
         Member member = Member.builder()

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.auth.service;
+
+public class AuthService {
+}

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -6,10 +6,15 @@ import org.springframework.transaction.annotation.Transactional;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.repository.AuthRepository;
+import sopt.univoice.domain.auth.repository.CollegeDepartmentRepository;
+import sopt.univoice.domain.universityData.entity.CollegeDepartment;
+import sopt.univoice.domain.universityData.entity.Department;
+import sopt.univoice.domain.universityData.repository.DepartmentRepository;
 import sopt.univoice.domain.user.entity.Member;
 import sopt.univoice.infra.external.S3Service;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +23,8 @@ public class AuthService {
 
     private final AuthRepository authRepository;
     private final S3Service s3Service;
+    private final DepartmentRepository departmentRepository;
+    private final CollegeDepartmentRepository collegeDepartmentRepository;
 
     public boolean isDuplicateEmail(CheckEmailRequest checkEmailRequest) {
         return authRepository.existsByEmail(checkEmailRequest.getEmail());
@@ -33,6 +40,19 @@ public class AuthService {
             throw new RuntimeException("이미지 업로드에 실패했습니다.", e);
         }
 
+        // departmentName을 통해 department 엔티티를 찾음
+        List<Department> departments = departmentRepository.findByDepartmentName(memberCreateRequest.getDepartmentName());
+        if (departments.isEmpty()) {
+            throw new RuntimeException("해당 학과가 존재하지 않습니다.");
+        }
+
+        // 적절한 department 선택 (예: 첫 번째 결과 사용)
+        Department department = departments.get(0);
+
+        // department 엔티티를 통해 collegeDepartment 엔티티를 찾음
+        CollegeDepartment collegeDepartment = collegeDepartmentRepository.findById(department.getCollegeDepartment().getId())
+                .orElseThrow(() -> new RuntimeException("해당 단과대학이 존재하지 않습니다."));
+
         Member member = Member.builder()
                 .admissionNumber(memberCreateRequest.getAdmissionNumber())
                 .name(memberCreateRequest.getName())
@@ -42,6 +62,7 @@ public class AuthService {
                 .studentCardImage(imageUrl)
                 .universityName(memberCreateRequest.getUniversityName())
                 .departmentName(memberCreateRequest.getDepartmentName())
+                .collegeDepartmentName(collegeDepartment.getCollegeDepartmentName())
                 .build();
 
         authRepository.save(member);

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package sopt.univoice.domain.auth.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.slack.api.Slack;
+import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.webhook.Payload;
 import com.slack.api.webhook.WebhookResponse;
 import lombok.RequiredArgsConstructor;
@@ -17,8 +18,16 @@ import sopt.univoice.domain.universityData.repository.DepartmentRepository;
 import sopt.univoice.domain.user.entity.Member;
 import sopt.univoice.infra.external.S3Service;
 
+import com.slack.api.model.block.Blocks;
+import com.slack.api.model.block.composition.BlockCompositions;
+import com.slack.api.model.block.element.BlockElements;
+
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
+
+import static com.slack.api.model.block.composition.BlockCompositions.plainText;
+import static com.slack.api.model.block.element.BlockElements.asElements;
 
 @Service
 @RequiredArgsConstructor
@@ -97,9 +106,17 @@ public class AuthService {
                 member.getDepartmentName()
         );
 
+        List<LayoutBlock> blocks = Arrays.asList(
+                Blocks.section(section -> section.text(BlockCompositions.markdownText(formattedMessage))),
+                Blocks.actions(actions -> actions.elements(asElements(
+                        BlockElements.button(b -> b.text(plainText(pt -> pt.text("승인"))).value("approve").actionId("approve_action")),
+                        BlockElements.button(b -> b.text(plainText(pt -> pt.text("거절"))).value("reject").actionId("reject_action"))
+                )))
+        );
+
         try {
             Payload payload = Payload.builder()
-                    .text(formattedMessage)
+                    .blocks(blocks)
                     .build();
             WebhookResponse response = slack.send(WEBHOOK_URL, payload);
             System.out.println(response);

--- a/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
+++ b/src/main/java/sopt/univoice/domain/auth/service/AuthService.java
@@ -8,6 +8,8 @@ import com.slack.api.webhook.WebhookResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import sopt.univoice.domain.affiliation.entity.Affiliation;
+import sopt.univoice.domain.affiliation.repository.AffiliationRepository;
 import sopt.univoice.domain.auth.dto.CheckEmailRequest;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.repository.AuthRepository;
@@ -41,6 +43,7 @@ public class AuthService {
     private final S3Service s3Service;
     private final DepartmentRepository departmentRepository;
     private final CollegeDepartmentRepository collegeDepartmentRepository;
+    private final AffiliationRepository affiliationRepository;
     private final ObjectMapper objectMapper;
 
     public boolean isDuplicateEmail(CheckEmailRequest checkEmailRequest) {
@@ -69,6 +72,9 @@ public class AuthService {
         CollegeDepartment collegeDepartment = collegeDepartmentRepository.findById(department.getCollegeDepartment().getId())
                 .orElseThrow(() -> new RuntimeException("해당 단과대학이 존재하지 않습니다."));
 
+        Affiliation affiliation = new Affiliation();
+        affiliationRepository.save(affiliation);
+
         Member member = Member.builder()
                 .admissionNumber(memberCreateRequest.getAdmissionNumber())
                 .name(memberCreateRequest.getName())
@@ -79,6 +85,7 @@ public class AuthService {
                 .universityName(memberCreateRequest.getUniversityName())
                 .departmentName(memberCreateRequest.getDepartmentName())
                 .collegeDepartmentName(collegeDepartment.getCollegeDepartmentName())
+                .affiliation(affiliation)
                 .build();
 
         authRepository.save(member);

--- a/src/main/java/sopt/univoice/domain/firstcome/entity/FirstCome.java
+++ b/src/main/java/sopt/univoice/domain/firstcome/entity/FirstCome.java
@@ -1,4 +1,37 @@
 package sopt.univoice.domain.firstcome.entity;
 
-public class FirstCome {
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.univoice.domain.notice.entity.Notice;
+import sopt.univoice.infra.persistence.BaseTimeEntity;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FirstCome extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long FirstComeNumberLimit;
+
+
+    private Long FirstComeNumberCurrent;
+
+    @OneToOne
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+    @OneToMany(mappedBy = "firstCome", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<FirstComeNumberHistory> firstComeNumberHistories;
+
+
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/firstcome/entity/FirstComeNumberHistory.java
+++ b/src/main/java/sopt/univoice/domain/firstcome/entity/FirstComeNumberHistory.java
@@ -1,4 +1,20 @@
 package sopt.univoice.domain.firstcome.entity;
 
-public class FirstComeNumberHistory {
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.univoice.infra.persistence.BaseTimeEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class FirstComeNumberHistory extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "first_come_id")
+    private FirstCome firstCome;
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -44,4 +44,27 @@ public class NoticeController {
     }
 
 
+
+    @PostMapping("/save/{noticeId}")
+    public ResponseEntity<SuccessStatusResponse<Object>> saveNotice(@PathVariable Long noticeId) {
+
+        noticeService.saveNotice(noticeId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.SAVE_NOTICE_SUCCESS, null));
+    }
+
+    @PostMapping("/save/cancle/{noticeId}")
+    public ResponseEntity<SuccessStatusResponse<Object>> saveCancleNotice(@PathVariable Long noticeId) {
+
+        noticeService.saveCancleNotice(noticeId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.SAVE_CANCLE_NOTICE_SUCCESS, null));
+    }
+
+
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -95,4 +95,15 @@ public class NoticeController {
     }
 
 
+    @GetMapping("/college-department")
+    public ResponseEntity<SuccessStatusResponse<Object>> getCollegeDepartmentNoticeByUserUniversity() {
+        GetUniversityNoticesResponseDTO response = noticeService.getCollegeDepartmentNoticeByUserUniversity();
+
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_COLLEGE_NOTICE_SUCCESS, response));
+    }
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -23,11 +23,9 @@ public class NoticeController {
 
     @PostMapping()
     public ResponseEntity<SuccessStatusResponse<Void>> createPost(@ModelAttribute NoticeCreateRequest noticeCreateRequest) {
-
+        System.out.println("createPost method called with request: " + noticeCreateRequest);
         noticeService.createPost(noticeCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.CREATE_NOTICE_SUCCESS, null));
     }
-
-
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -4,10 +4,7 @@ package sopt.univoice.domain.notice.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
@@ -30,11 +27,21 @@ public class NoticeController {
     }
 
 
+    @PostMapping("/like/{noticeId}")
+    public ResponseEntity<SuccessStatusResponse<Object>> likeNotice(@PathVariable Long noticeId) {
 
+        noticeService.likeNotice(noticeId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.LIKE_NOTICE_SUCCESS, null));
+    }
 
+    @PostMapping("/like/cancle/{noticeId}")
+    public ResponseEntity<SuccessStatusResponse<Object>> likeCancleNotice(@PathVariable Long noticeId) {
 
-
-
+        noticeService.likeCancleNotice(noticeId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.LIKE_CANCLE_NOTICE_SUCCESS, null));
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -76,7 +76,13 @@ public class NoticeController {
                 .body(SuccessStatusResponse.of(SuccessMessage.SAVE_ALL_NOTICE_SUCCESS, notices));
     }
 
+    @PostMapping("/view-count/{noticeId}")
+    public ResponseEntity<SuccessStatusResponse<Object>> viewCount(@PathVariable Long noticeId) {
 
+        noticeService.viewCount(noticeId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessStatusResponse.of(SuccessMessage.VIEW_NOTICE_SUCCESS, null));
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.service.AuthService;
+import sopt.univoice.domain.notice.dto.GetAllNoticesResponseDTO;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
 import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
 import sopt.univoice.domain.notice.entity.Notice;
@@ -83,6 +84,17 @@ public class NoticeController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.VIEW_NOTICE_SUCCESS, null));
     }
+
+
+    @GetMapping("/all")
+    public ResponseEntity<SuccessStatusResponse<Object>> getAllNoticeByUserUniversity() {
+        GetAllNoticesResponseDTO response = noticeService.getAllNoticeByUserUniversity();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_NOTICE_SUCCESS, response));
+    }
+
+
+
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -21,11 +21,20 @@ import sopt.univoice.infra.common.dto.SuccessStatusResponse;
 public class NoticeController {
     private final NoticeService noticeService;
 
-    @PostMapping()
+    @PostMapping("/create")
     public ResponseEntity<SuccessStatusResponse<Void>> createPost(@ModelAttribute NoticeCreateRequest noticeCreateRequest) {
         System.out.println("createPost method called with request: " + noticeCreateRequest);
         noticeService.createPost(noticeCreateRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.CREATE_NOTICE_SUCCESS, null));
     }
+
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -116,6 +116,14 @@ public class NoticeController {
     }
 
 
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<SuccessStatusResponse<NoticeDetailResponseDTO>> getNoticeById(@PathVariable Long noticeId) {
+        NoticeDetailResponseDTO response = noticeService.getNoticeById(noticeId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_Detail_NOTICE_SUCCESS, response));
+    }
+
+
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -8,9 +8,13 @@ import org.springframework.web.bind.annotation.*;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
+import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
+import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.domain.notice.service.NoticeService;
 import sopt.univoice.infra.common.dto.SuccessMessage;
 import sopt.univoice.infra.common.dto.SuccessStatusResponse;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/notice")
@@ -31,7 +35,7 @@ public class NoticeController {
     public ResponseEntity<SuccessStatusResponse<Object>> likeNotice(@PathVariable Long noticeId) {
 
         noticeService.likeNotice(noticeId);
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.LIKE_NOTICE_SUCCESS, null));
     }
 
@@ -39,7 +43,7 @@ public class NoticeController {
     public ResponseEntity<SuccessStatusResponse<Object>> likeCancleNotice(@PathVariable Long noticeId) {
 
         noticeService.likeCancleNotice(noticeId);
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.LIKE_CANCLE_NOTICE_SUCCESS, null));
     }
 
@@ -49,7 +53,7 @@ public class NoticeController {
     public ResponseEntity<SuccessStatusResponse<Object>> saveNotice(@PathVariable Long noticeId) {
 
         noticeService.saveNotice(noticeId);
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.SAVE_NOTICE_SUCCESS, null));
     }
 
@@ -57,14 +61,20 @@ public class NoticeController {
     public ResponseEntity<SuccessStatusResponse<Object>> saveCancleNotice(@PathVariable Long noticeId) {
 
         noticeService.saveCancleNotice(noticeId);
-        return ResponseEntity.status(HttpStatus.OK)
+        return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.SAVE_CANCLE_NOTICE_SUCCESS, null));
     }
 
 
 
 
+    @GetMapping("/save/all")
+    public ResponseEntity<SuccessStatusResponse<List<NoticeSaveDTO>>> getSaveNoticeByUser() {
 
+        List<NoticeSaveDTO> notices = noticeService.getSaveNoticeByUser();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.SAVE_ALL_NOTICE_SUCCESS, notices));
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -1,0 +1,33 @@
+package sopt.univoice.domain.notice.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.univoice.domain.auth.dto.MemberCreateRequest;
+import sopt.univoice.domain.auth.service.AuthService;
+import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
+import sopt.univoice.domain.notice.service.NoticeService;
+import sopt.univoice.infra.common.dto.SuccessMessage;
+import sopt.univoice.infra.common.dto.SuccessStatusResponse;
+
+@RestController
+@RequestMapping("/api/v1/notice")
+@RequiredArgsConstructor
+public class NoticeController {
+    private final NoticeService noticeService;
+
+    @PostMapping()
+    public ResponseEntity<SuccessStatusResponse<Void>> createPost(@ModelAttribute NoticeCreateRequest noticeCreateRequest) {
+
+        noticeService.createPost(noticeCreateRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(SuccessStatusResponse.of(SuccessMessage.CREATE_NOTICE_SUCCESS, null));
+    }
+
+
+}

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -5,10 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import sopt.univoice.domain.notice.dto.GetAllNoticesResponseDTO;
-import sopt.univoice.domain.notice.dto.GetMainNoticesResponseDTO;
-import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
-import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
+import sopt.univoice.domain.notice.dto.*;
 import sopt.univoice.domain.notice.service.NoticeService;
 import sopt.univoice.infra.common.dto.SuccessMessage;
 import sopt.univoice.infra.common.dto.SuccessStatusResponse;
@@ -107,7 +104,17 @@ public class NoticeController {
 
 
         return ResponseEntity.status(HttpStatus.OK)
-                .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_DEPARTMENT_SUCCESS, response));
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_DEPARTMENT_NOTICE_SUCCESS, response));
     }
+
+
+    @GetMapping("/quick")
+    public ResponseEntity<SuccessStatusResponse<List<QuickQueryNoticeDTO>>> getQuickNoticeByUserUniversity(@RequestParam String affiliation) {
+        List<QuickQueryNoticeDTO> response = noticeService.getQuickNoticeByUserUniversity(affiliation);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_QUICK_NOTICE_SUCCESS, response));
+    }
+
+
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -107,13 +107,14 @@ public class NoticeController {
                 .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_DEPARTMENT_NOTICE_SUCCESS, response));
     }
 
-
-    @GetMapping("/quick")
-    public ResponseEntity<SuccessStatusResponse<List<QuickQueryNoticeDTO>>> getQuickNoticeByUserUniversity(@RequestParam String affiliation) {
-        List<QuickQueryNoticeDTO> response = noticeService.getQuickNoticeByUserUniversity(affiliation);
+    @PostMapping("/quick")
+    public ResponseEntity<SuccessStatusResponse<List<QuickQueryNoticeDTO>>> getQuickNoticeByUserUniversity(@RequestBody AffiliationRequestDTO request) {
+        System.out.println("Received Affiliation Request: " + request.getAffiliation());
+        List<QuickQueryNoticeDTO> response = noticeService.getQuickNoticeByUserUniversity(request.getAffiliation());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.GET_QUICK_NOTICE_SUCCESS, response));
     }
+
 
 
 

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -77,4 +77,6 @@ public class NoticeController {
     }
 
 
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import sopt.univoice.domain.auth.dto.MemberCreateRequest;
 import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.notice.dto.GetAllNoticesResponseDTO;
+import sopt.univoice.domain.notice.dto.GetUniversityNoticesResponseDTO;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
 import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
 import sopt.univoice.domain.notice.entity.Notice;
@@ -31,7 +32,6 @@ public class NoticeController {
                 .body(SuccessStatusResponse.of(SuccessMessage.CREATE_NOTICE_SUCCESS, null));
     }
 
-
     @PostMapping("/like/{noticeId}")
     public ResponseEntity<SuccessStatusResponse<Object>> likeNotice(@PathVariable Long noticeId) {
 
@@ -47,8 +47,6 @@ public class NoticeController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(SuccessStatusResponse.of(SuccessMessage.LIKE_CANCLE_NOTICE_SUCCESS, null));
     }
-
-
 
     @PostMapping("/save/{noticeId}")
     public ResponseEntity<SuccessStatusResponse<Object>> saveNotice(@PathVariable Long noticeId) {
@@ -66,9 +64,6 @@ public class NoticeController {
                 .body(SuccessStatusResponse.of(SuccessMessage.SAVE_CANCLE_NOTICE_SUCCESS, null));
     }
 
-
-
-
     @GetMapping("/save/all")
     public ResponseEntity<SuccessStatusResponse<List<NoticeSaveDTO>>> getSaveNoticeByUser() {
 
@@ -85,7 +80,6 @@ public class NoticeController {
                 .body(SuccessStatusResponse.of(SuccessMessage.VIEW_NOTICE_SUCCESS, null));
     }
 
-
     @GetMapping("/all")
     public ResponseEntity<SuccessStatusResponse<Object>> getAllNoticeByUserUniversity() {
         GetAllNoticesResponseDTO response = noticeService.getAllNoticeByUserUniversity();
@@ -93,8 +87,12 @@ public class NoticeController {
                 .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_NOTICE_SUCCESS, response));
     }
 
-
-
+    @GetMapping("/university")
+    public ResponseEntity<SuccessStatusResponse<Object>> getUniversityNoticeByUserUniversity() {
+        GetUniversityNoticesResponseDTO response = noticeService.getUniversityNoticeByUserUniversity();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_UNIVERSITY_NOTICE_SUCCESS, response));
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
+++ b/src/main/java/sopt/univoice/domain/notice/controller/NoticeController.java
@@ -5,13 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import sopt.univoice.domain.auth.dto.MemberCreateRequest;
-import sopt.univoice.domain.auth.service.AuthService;
 import sopt.univoice.domain.notice.dto.GetAllNoticesResponseDTO;
-import sopt.univoice.domain.notice.dto.GetUniversityNoticesResponseDTO;
+import sopt.univoice.domain.notice.dto.GetMainNoticesResponseDTO;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
 import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
-import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.domain.notice.service.NoticeService;
 import sopt.univoice.infra.common.dto.SuccessMessage;
 import sopt.univoice.infra.common.dto.SuccessStatusResponse;
@@ -89,7 +86,7 @@ public class NoticeController {
 
     @GetMapping("/university")
     public ResponseEntity<SuccessStatusResponse<Object>> getUniversityNoticeByUserUniversity() {
-        GetUniversityNoticesResponseDTO response = noticeService.getUniversityNoticeByUserUniversity();
+        GetMainNoticesResponseDTO response = noticeService.getUniversityNoticeByUserUniversity();
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_UNIVERSITY_NOTICE_SUCCESS, response));
     }
@@ -97,13 +94,20 @@ public class NoticeController {
 
     @GetMapping("/college-department")
     public ResponseEntity<SuccessStatusResponse<Object>> getCollegeDepartmentNoticeByUserUniversity() {
-        GetUniversityNoticesResponseDTO response = noticeService.getCollegeDepartmentNoticeByUserUniversity();
+        GetMainNoticesResponseDTO response = noticeService.getCollegeDepartmentNoticeByUserUniversity();
 
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_COLLEGE_NOTICE_SUCCESS, response));
     }
 
+    @GetMapping("/department")
+    public ResponseEntity<SuccessStatusResponse<Object>> getDepartmentNoticeByUserUniversity() {
+        GetMainNoticesResponseDTO response = noticeService.getDepartmentNoticeByUserUniversity();
 
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.GET_ALL_DEPARTMENT_SUCCESS, response));
+    }
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/dto/AffiliationRequestDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/AffiliationRequestDTO.java
@@ -1,0 +1,23 @@
+package sopt.univoice.domain.notice.dto;
+
+public class AffiliationRequestDTO {
+    private String affiliation;
+
+    // 기본 생성자
+    public AffiliationRequestDTO() {}
+
+    // 파라미터가 있는 생성자
+    public AffiliationRequestDTO(String affiliation) {
+        this.affiliation = affiliation;
+    }
+
+    // getter와 setter 메소드
+    public String getAffiliation() {
+        return affiliation;
+    }
+
+    public void setAffiliation(String affiliation) {
+        this.affiliation = affiliation;
+    }
+}
+

--- a/src/main/java/sopt/univoice/domain/notice/dto/GetAllNoticesResponseDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/GetAllNoticesResponseDTO.java
@@ -1,0 +1,16 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetAllNoticesResponseDTO {
+    private QuickScanDTO quickScans;
+    private List<NoticeDTO> notices;
+}
+

--- a/src/main/java/sopt/univoice/domain/notice/dto/GetMainNoticesResponseDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/GetMainNoticesResponseDTO.java
@@ -11,7 +11,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetUniversityNoticesResponseDTO {
+public class GetMainNoticesResponseDTO {
     private QuickScanResponseDTO quickScans;
     private List<NoticeResponseDTO> notices;
 }

--- a/src/main/java/sopt/univoice/domain/notice/dto/GetUniversityNoticesResponseDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/GetUniversityNoticesResponseDTO.java
@@ -1,0 +1,17 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetUniversityNoticesResponseDTO {
+    private QuickScanResponseDTO quickScans;
+    private List<NoticeResponseDTO> notices;
+}

--- a/src/main/java/sopt/univoice/domain/notice/dto/NoticeCreateRequest.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/NoticeCreateRequest.java
@@ -2,6 +2,7 @@ package sopt.univoice.domain.notice.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -19,9 +20,12 @@ public class NoticeCreateRequest {
 
     private String content;
 
-    private Optional<Long> target = Optional.empty();
-    private Optional<LocalDateTime> startTime = Optional.empty();
-    private Optional<LocalDateTime> endTime = Optional.empty();
+    private String target;
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startTime;
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endTime;
 
     private List<MultipartFile> studentCardImages;
 

--- a/src/main/java/sopt/univoice/domain/notice/dto/NoticeCreateRequest.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/NoticeCreateRequest.java
@@ -1,0 +1,28 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Setter
+@Getter
+@NoArgsConstructor
+//@AllArgsConstructor
+public class NoticeCreateRequest {
+
+
+    private String title;
+
+    private String content;
+
+    private Optional<Long> target = Optional.empty();
+    private Optional<LocalDateTime> startTime = Optional.empty();
+    private Optional<LocalDateTime> endTime = Optional.empty();
+
+    private List<MultipartFile> studentCardImages;
+
+}

--- a/src/main/java/sopt/univoice/domain/notice/dto/NoticeDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/NoticeDTO.java
@@ -1,18 +1,20 @@
 package sopt.univoice.domain.notice.dto;
 
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
-@Data
+@Getter
+@NoArgsConstructor
 @AllArgsConstructor
-public class NoticeSaveDTO {
+public class NoticeDTO {
     private Long id;
-    private String title;
-    private Long viewCount;
-    private Long noticeLike;
-    private String category;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
+    private String title;
+    private Long likeCount;
+    private Long saveCount;
+    private String category;
 }

--- a/src/main/java/sopt/univoice/domain/notice/dto/NoticeDetailResponseDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/NoticeDetailResponseDTO.java
@@ -1,0 +1,25 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NoticeDetailResponseDTO {
+    private Long id;
+    private String title;
+    private String content;
+    private Long noticeLike;
+    private Long viewCount;
+    private String target;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String category;
+    private String contentSummary;
+    private Long memberId;
+    private String writeAffiliation;
+    private List<String> noticeImages;
+}

--- a/src/main/java/sopt/univoice/domain/notice/dto/NoticeResponseDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/NoticeResponseDTO.java
@@ -1,0 +1,22 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoticeResponseDTO {
+    private Long id;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String title;
+    private Long likeCount;
+    private Long saveCount;
+    private String category;
+}

--- a/src/main/java/sopt/univoice/domain/notice/dto/NoticeSaveDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/NoticeSaveDTO.java
@@ -1,0 +1,18 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+public class NoticeSaveDTO {
+    private Long id;
+    private String title;
+    private Long viewCount;
+    private Long noticeLike;
+    private Long category;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+}

--- a/src/main/java/sopt/univoice/domain/notice/dto/QuickQueryNoticeDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/QuickQueryNoticeDTO.java
@@ -1,0 +1,19 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class QuickQueryNoticeDTO {
+    private Long id;
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+    private String title;
+    private Long likeCount;
+    private Long saveCount;
+    private String category;
+}
+

--- a/src/main/java/sopt/univoice/domain/notice/dto/QuickScanDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/QuickScanDTO.java
@@ -1,0 +1,18 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuickScanDTO {
+    private String universityName;
+    private int universityNameCount;
+    private String collegeDepartmentName;
+    private int collegeDepartmentCount;
+    private String departmentName;
+    private int departmentCount;
+}
+

--- a/src/main/java/sopt/univoice/domain/notice/dto/QuickScanResponseDTO.java
+++ b/src/main/java/sopt/univoice/domain/notice/dto/QuickScanResponseDTO.java
@@ -1,0 +1,19 @@
+package sopt.univoice.domain.notice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class QuickScanResponseDTO {
+    private String universityName;
+    private long universityNameCount;
+    private String collegeDepartmentName;
+    private long collegeDepartmentCount;
+    private String departmentName;
+    private long departmentCount;
+}

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -87,6 +87,21 @@ public class Notice   extends BaseTimeEntity {
         return viewCount;
     }
 
-
+    @Override
+    public String toString() {
+        return "Notice{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", noticeLike=" + noticeLike +
+                ", viewCount=" + viewCount +
+                ", target='" + target + '\'' +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", category='" + category + '\'' +
+                ", contentSummary='" + contentSummary + '\'' +
+                ", member=" + (member != null ? member.getId() : "null") +
+                '}';
+    }
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -37,6 +37,7 @@ public class Notice   extends BaseTimeEntity {
 
     private String category;
 
+    @Column(length = 1000)
     private String contentSummary;
 
 
@@ -61,7 +62,7 @@ public class Notice   extends BaseTimeEntity {
     private List<NoticeLike> noticeLikes;
 
     @Builder
-    public Notice(String title, String content, String target, LocalDateTime startTime, LocalDateTime endTime, Member member, String contentSummary) {
+    public Notice(String title, String content, String target, LocalDateTime startTime, LocalDateTime endTime, Member member, String contentSummary, String category) {
         this.title = title;
         this.content = content;
         this.target = target;
@@ -71,6 +72,7 @@ public class Notice   extends BaseTimeEntity {
         this.noticeLike = 0L;
         this.viewCount = 0L;
         this.contentSummary = contentSummary;
+        this.category = category;
     }
 
 
@@ -87,21 +89,6 @@ public class Notice   extends BaseTimeEntity {
         return viewCount;
     }
 
-    @Override
-    public String toString() {
-        return "Notice{" +
-                "id=" + id +
-                ", title='" + title + '\'' +
-                ", content='" + content + '\'' +
-                ", noticeLike=" + noticeLike +
-                ", viewCount=" + viewCount +
-                ", target='" + target + '\'' +
-                ", startTime=" + startTime +
-                ", endTime=" + endTime +
-                ", category='" + category + '\'' +
-                ", contentSummary='" + contentSummary + '\'' +
-                ", member=" + (member != null ? member.getId() : "null") +
-                '}';
-    }
+
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -73,6 +73,8 @@ public class Notice   extends BaseTimeEntity {
     }
 
 
-
+    public void setNoticeLike(Long noticeLike) {
+        this.noticeLike = noticeLike;
+    }
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -2,6 +2,7 @@ package sopt.univoice.domain.notice.entity;
 
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.firstcome.entity.FirstCome;
@@ -56,5 +57,18 @@ public class Notice   extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<NoticeLike> noticeLikes;
+
+    @Builder
+    public Notice(String title, String content, Long target, LocalDateTime startTime, LocalDateTime endTime, Member member) {
+        this.title = title;
+        this.content = content;
+        this.target = target;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.member = member;
+    }
+
+
+
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -1,4 +1,60 @@
 package sopt.univoice.domain.notice.entity;
 
-public class Notice {
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.univoice.domain.firstcome.entity.FirstCome;
+import sopt.univoice.domain.user.entity.Member;
+import sopt.univoice.infra.persistence.BaseTimeEntity;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Notice   extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    private String title;
+
+    private String content;
+
+    private Long noticeLike;
+
+    private Long viewCount;
+    private Long target;
+
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+
+    private Long category;
+    private Long contentSummary;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private FirstCome firstCome;
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoticeImage> noticeImages;
+
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoticeView> noticeViews;
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SaveNotice> saveNotices;
+
+    @OneToMany(mappedBy = "notice", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoticeLike> noticeLikes;
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -77,4 +77,6 @@ public class Notice   extends BaseTimeEntity {
         this.noticeLike = noticeLike;
     }
 
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -26,9 +26,9 @@ public class Notice   extends BaseTimeEntity {
 
     private String content;
 
-    private Long noticeLike;
+    private Long noticeLike = 0L;
 
-    private Long viewCount;
+    private Long viewCount = 0L;
     private String target;
 
     private LocalDateTime startTime;
@@ -66,6 +66,8 @@ public class Notice   extends BaseTimeEntity {
         this.startTime = startTime;
         this.endTime = endTime;
         this.member = member;
+        this.noticeLike = 0L;
+        this.viewCount = 0L;
     }
 
 

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -35,7 +35,8 @@ public class Notice   extends BaseTimeEntity {
     private LocalDateTime endTime;
 
     private Long category;
-    private Long contentSummary;
+
+    private String contentSummary;
 
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -59,7 +60,7 @@ public class Notice   extends BaseTimeEntity {
     private List<NoticeLike> noticeLikes;
 
     @Builder
-    public Notice(String title, String content, String target, LocalDateTime startTime, LocalDateTime endTime, Member member) {
+    public Notice(String title, String content, String target, LocalDateTime startTime, LocalDateTime endTime, Member member, String contentSummary) {
         this.title = title;
         this.content = content;
         this.target = target;
@@ -68,6 +69,7 @@ public class Notice   extends BaseTimeEntity {
         this.member = member;
         this.noticeLike = 0L;
         this.viewCount = 0L;
+        this.contentSummary = contentSummary;
     }
 
 

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -24,6 +24,7 @@ public class Notice   extends BaseTimeEntity {
 
     private String title;
 
+    @Column(length = 1000)
     private String content;
 
     private Long noticeLike = 0L;

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -77,6 +77,15 @@ public class Notice   extends BaseTimeEntity {
         this.noticeLike = noticeLike;
     }
 
+    // 추가된 부분
+    public void setViewCount(Long viewCount) {
+        this.viewCount = viewCount;
+    }
+
+    public Long getViewCount() {
+        return viewCount;
+    }
+
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -34,7 +34,7 @@ public class Notice   extends BaseTimeEntity {
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 
-    private Long category;
+    private String category;
 
     private String contentSummary;
 

--- a/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/Notice.java
@@ -29,7 +29,7 @@ public class Notice   extends BaseTimeEntity {
     private Long noticeLike;
 
     private Long viewCount;
-    private Long target;
+    private String target;
 
     private LocalDateTime startTime;
     private LocalDateTime endTime;
@@ -59,7 +59,7 @@ public class Notice   extends BaseTimeEntity {
     private List<NoticeLike> noticeLikes;
 
     @Builder
-    public Notice(String title, String content, Long target, LocalDateTime startTime, LocalDateTime endTime, Member member) {
+    public Notice(String title, String content, String target, LocalDateTime startTime, LocalDateTime endTime, Member member) {
         this.title = title;
         this.content = content;
         this.target = target;

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeImage.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeImage.java
@@ -1,6 +1,7 @@
 package sopt.univoice.domain.notice.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,9 +13,18 @@ public class NoticeImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String  NoticeImage;
+    private String  noticeImage;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notice_id")
     private Notice notice;
+
+    @Builder
+    public NoticeImage(String noticeImage, Notice notice) {
+        this.noticeImage = noticeImage;
+        this.notice = notice;
+    }
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeImage.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeImage.java
@@ -1,4 +1,20 @@
 package sopt.univoice.domain.notice.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
 public class NoticeImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String  NoticeImage;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeLike.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeLike.java
@@ -1,4 +1,18 @@
 package sopt.univoice.domain.notice.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
 public class NoticeLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeLike.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeLike.java
@@ -1,6 +1,7 @@
 package sopt.univoice.domain.notice.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.user.entity.Member;
@@ -22,6 +23,12 @@ public class NoticeLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public NoticeLike(Notice notice, Member member) {
+        this.notice = notice;
+        this.member = member;
+    }
 
 
 

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeLike.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeLike.java
@@ -3,6 +3,7 @@ package sopt.univoice.domain.notice.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sopt.univoice.domain.user.entity.Member;
 
 @Entity
 @Getter
@@ -15,4 +16,13 @@ public class NoticeLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notice_id")
     private Notice notice;
+
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
@@ -1,6 +1,7 @@
 package sopt.univoice.domain.notice.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.user.entity.Member;
@@ -18,8 +19,21 @@ public class NoticeView {
     private Notice notice;
 
 
+    private boolean readAt;
+
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+
+
+    @Builder
+    public NoticeView(Notice notice, Member member, boolean readAt) {
+        this.notice = notice;
+        this.member = member;
+        this.readAt = readAt;
+    }
+
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
@@ -1,4 +1,20 @@
 package sopt.univoice.domain.notice.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
 public class NoticeView {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
@@ -3,6 +3,7 @@ package sopt.univoice.domain.notice.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sopt.univoice.domain.user.entity.Member;
 
 @Entity
 @Getter
@@ -16,5 +17,9 @@ public class NoticeView {
     @JoinColumn(name = "notice_id")
     private Notice notice;
 
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/NoticeView.java
@@ -34,6 +34,9 @@ public class NoticeView {
         this.member = member;
         this.readAt = readAt;
     }
-
+    // Setter for readAt
+    public void setReadAt(boolean readAt) {
+        this.readAt = readAt;
+    }
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/SaveNotice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/SaveNotice.java
@@ -1,4 +1,19 @@
 package sopt.univoice.domain.notice.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
 public class SaveNotice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id")
+    private Notice notice;
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/SaveNotice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/SaveNotice.java
@@ -1,6 +1,7 @@
 package sopt.univoice.domain.notice.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.user.entity.Member;
@@ -22,4 +23,10 @@ public class SaveNotice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @Builder
+    public SaveNotice(Notice notice, Member member) {
+        this.notice = notice;
+        this.member = member;
+    }
 }

--- a/src/main/java/sopt/univoice/domain/notice/entity/SaveNotice.java
+++ b/src/main/java/sopt/univoice/domain/notice/entity/SaveNotice.java
@@ -3,6 +3,7 @@ package sopt.univoice.domain.notice.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import sopt.univoice.domain.user.entity.Member;
 
 
 @Entity
@@ -16,4 +17,9 @@ public class SaveNotice {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "notice_id")
     private Notice notice;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 }

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeImageRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeImageRepository.java
@@ -1,0 +1,8 @@
+package sopt.univoice.domain.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.notice.entity.NoticeImage;
+
+public interface NoticeImageRepository extends JpaRepository<NoticeImage, Long> {
+}
+

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeLikeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeLikeRepository.java
@@ -1,0 +1,12 @@
+package sopt.univoice.domain.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.notice.entity.Notice;
+import sopt.univoice.domain.notice.entity.NoticeLike;
+import sopt.univoice.domain.user.entity.Member;
+
+import java.util.Optional;
+
+public interface NoticeLikeRepository extends JpaRepository<NoticeLike, Long> {
+    Optional<NoticeLike> findByNoticeAndMember(Notice notice, Member member);
+}

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
@@ -14,6 +14,10 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     long countByMemberCollegeDepartmentNameAndMemberAffiliationAffiliation(String collegeDepartmentName, String affiliation);
     long countByMemberDepartmentNameAndMemberAffiliationAffiliation(String departmentName, String affiliation);
     List<Notice> findByMemberUniversityNameAndMemberAffiliationAffiliation(String universityName, String affiliation);
+
+
+    @Query("SELECT n FROM Notice n WHERE n.member.universityName = :universityName AND n.member.affiliation.affiliation = :affiliation")
+    List<Notice> findByMemberUniversityNameAndAffiliationAffiliation(String universityName, String affiliation);
 }
 
 

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
@@ -9,6 +9,11 @@ import java.util.List;
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
     @Query("SELECT n FROM Notice n WHERE n.member.universityName = :universityName")
     List<Notice> findAllByMemberUniversityName(String universityName);
+
+    long countByMemberUniversityNameAndMemberAffiliationAffiliation(String universityName, String affiliation);
+    long countByMemberCollegeDepartmentNameAndMemberAffiliationAffiliation(String collegeDepartmentName, String affiliation);
+    long countByMemberDepartmentNameAndMemberAffiliationAffiliation(String departmentName, String affiliation);
+    List<Notice> findByMemberUniversityNameAndMemberAffiliationAffiliation(String universityName, String affiliation);
 }
 
 

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,7 @@
+package sopt.univoice.domain.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.notice.entity.Notice;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+}

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeRepository.java
@@ -1,7 +1,14 @@
 package sopt.univoice.domain.notice.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import sopt.univoice.domain.notice.entity.Notice;
 
+import java.util.List;
+
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
+    @Query("SELECT n FROM Notice n WHERE n.member.universityName = :universityName")
+    List<Notice> findAllByMemberUniversityName(String universityName);
 }
+
+

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeViewRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeViewRepository.java
@@ -5,10 +5,12 @@ import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.domain.notice.entity.NoticeView;
 import sopt.univoice.domain.user.entity.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface NoticeViewRepository extends JpaRepository<NoticeView, Long> {
     Optional<NoticeView> findByNoticeAndMember(Notice notice, Member member);
+    List<NoticeView> findByMemberIdAndReadAtFalse(Long memberId);
 }
 
 

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeViewRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeViewRepository.java
@@ -1,0 +1,8 @@
+package sopt.univoice.domain.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.notice.entity.NoticeView;
+
+public interface NoticeViewRepository extends JpaRepository<NoticeView, Long> {
+}
+

--- a/src/main/java/sopt/univoice/domain/notice/repository/NoticeViewRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/NoticeViewRepository.java
@@ -1,8 +1,14 @@
 package sopt.univoice.domain.notice.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.domain.notice.entity.NoticeView;
+import sopt.univoice.domain.user.entity.Member;
+
+import java.util.Optional;
 
 public interface NoticeViewRepository extends JpaRepository<NoticeView, Long> {
+    Optional<NoticeView> findByNoticeAndMember(Notice notice, Member member);
 }
+
 

--- a/src/main/java/sopt/univoice/domain/notice/repository/SaveNoticeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/SaveNoticeRepository.java
@@ -1,0 +1,16 @@
+package sopt.univoice.domain.notice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.notice.entity.Notice;
+import sopt.univoice.domain.notice.entity.NoticeLike;
+import sopt.univoice.domain.notice.entity.SaveNotice;
+import sopt.univoice.domain.user.entity.Member;
+
+import java.util.Optional;
+
+public interface SaveNoticeRepository extends JpaRepository<SaveNotice, Long>{
+    Optional<SaveNotice> findByNoticeAndMember(Notice notice, Member member);
+}
+
+
+

--- a/src/main/java/sopt/univoice/domain/notice/repository/SaveNoticeRepository.java
+++ b/src/main/java/sopt/univoice/domain/notice/repository/SaveNoticeRepository.java
@@ -6,10 +6,12 @@ import sopt.univoice.domain.notice.entity.NoticeLike;
 import sopt.univoice.domain.notice.entity.SaveNotice;
 import sopt.univoice.domain.user.entity.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SaveNoticeRepository extends JpaRepository<SaveNotice, Long>{
     Optional<SaveNotice> findByNoticeAndMember(Notice notice, Member member);
+    List<SaveNotice> findByMember(Member member);
 }
 
 

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -1,0 +1,75 @@
+package sopt.univoice.domain.notice.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import sopt.univoice.domain.auth.PrincipalHandler;
+import sopt.univoice.domain.auth.repository.AuthRepository;
+import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
+import sopt.univoice.domain.notice.entity.Notice;
+import sopt.univoice.domain.notice.entity.NoticeImage;
+import sopt.univoice.domain.notice.repository.NoticeImageRepository;
+import sopt.univoice.domain.notice.repository.NoticeRepository;
+import sopt.univoice.domain.user.entity.Member;
+import sopt.univoice.domain.affiliation.entity.Role;
+import sopt.univoice.infra.common.exception.UnauthorizedException;
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+import sopt.univoice.infra.external.S3Service;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+    private final NoticeImageRepository noticeImageRepository;
+    private final AuthRepository authRepository;
+    private final PrincipalHandler principalHandler;
+    private final S3Service s3Service;
+
+    @Transactional
+    public void createPost(NoticeCreateRequest noticeCreateRequest) {
+        Long memberId = principalHandler.getUserIdFromPrincipal();
+        Member member = authRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+
+        // 사용자 권한 확인
+        if (member.getAffiliation().getRole() != Role.APPROVEADMIN) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+
+        // Notice 엔티티 생성 및 저장
+        Notice notice = Notice.builder()
+                .title(noticeCreateRequest.getTitle())
+                .content(noticeCreateRequest.getContent())
+                .target(noticeCreateRequest.getTarget().orElse(null))
+                .startTime(noticeCreateRequest.getStartTime().orElse(null))
+                .endTime(noticeCreateRequest.getEndTime().orElse(null))
+                .member(member)
+                .build();
+        noticeRepository.save(notice);
+
+        // NoticeImage 엔티티 생성 및 저장
+        for (MultipartFile file : noticeCreateRequest.getStudentCardImages()) {
+            String fileName = storeFile(file); // 파일 저장 로직 필요
+            NoticeImage noticeImage = NoticeImage.builder()
+                    .notice(notice)
+                    .noticeImage(fileName)
+                    .build();
+            noticeImageRepository.save(noticeImage);
+        }
+    }
+
+    private String storeFile(MultipartFile file) {
+        try {
+            return s3Service.uploadImage("notice-images/", file);
+        } catch (IOException e) {
+            throw new RuntimeException("파일 업로드에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -8,6 +8,7 @@ import org.springframework.web.multipart.MultipartFile;
 import sopt.univoice.domain.auth.PrincipalHandler;
 import sopt.univoice.domain.auth.repository.AuthRepository;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
+import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
 import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.domain.notice.entity.NoticeImage;
 import sopt.univoice.domain.notice.entity.NoticeLike;
@@ -26,6 +27,7 @@ import sopt.univoice.infra.external.S3Service;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -176,6 +178,30 @@ public class NoticeService {
         saveNoticeRepository.delete(saveNotice);
     }
 
+    @Transactional(readOnly = true)
+    public List<NoticeSaveDTO> getSaveNoticeByUser() {
+        Long memberId = principalHandler.getUserIdFromPrincipal();
+
+        Member member = authRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+
+        List<SaveNotice> saveNotices = saveNoticeRepository.findByMember(member);
+
+        return saveNotices.stream()
+                .map(saveNotice -> {
+                    Notice notice = saveNotice.getNotice();
+                    return new NoticeSaveDTO(
+                            notice.getId(),
+                            notice.getTitle(),
+                            notice.getViewCount(),
+                            notice.getNoticeLike(),
+                            notice.getCategory(),
+                            notice.getStartTime(),
+                            notice.getEndTime()
+                    );
+                })
+                .collect(Collectors.toList());
+    }
 
 
 

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -279,6 +279,42 @@ public class NoticeService {
         return new GetAllNoticesResponseDTO(quickScans, noticeDTOs);
     }
 
+    @Transactional
+    public GetUniversityNoticesResponseDTO getUniversityNoticeByUserUniversity() {
+        Long memberId = principalHandler.getUserIdFromPrincipal();
 
+        Member member = authRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid member ID"));
 
+        String universityName = member.getUniversityName();
+        String collegeDepartmentName = member.getCollegeDepartmentName();
+        String departmentName = member.getDepartmentName();
+
+        long universityNameCount = noticeRepository.countByMemberUniversityNameAndMemberAffiliationAffiliation(universityName, "총학생회");
+        long collegeDepartmentCount = noticeRepository.countByMemberCollegeDepartmentNameAndMemberAffiliationAffiliation(collegeDepartmentName, "단과대학학생회");
+        long departmentCount = noticeRepository.countByMemberDepartmentNameAndMemberAffiliationAffiliation(departmentName, "과학생회");
+
+        List<Notice> universityNotices = noticeRepository.findByMemberUniversityNameAndMemberAffiliationAffiliation(universityName, "총학생회");
+
+        List<NoticeResponseDTO> noticeResponseDTOs = universityNotices.stream().map(notice -> new NoticeResponseDTO(
+                notice.getId(),
+                notice.getStartTime(),
+                notice.getEndTime(),
+                notice.getTitle(),
+                notice.getNoticeLike(),
+                (long) notice.getSaveNotices().size(),
+                notice.getCategory()
+        )).collect(Collectors.toList());
+
+        QuickScanResponseDTO quickScans = new QuickScanResponseDTO(
+                universityName,
+                universityNameCount,
+                collegeDepartmentName,
+                collegeDepartmentCount,
+                departmentName,
+                departmentCount
+        );
+
+        return new GetUniversityNoticesResponseDTO(quickScans, noticeResponseDTOs);
+    }
 }

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -161,8 +161,6 @@ public class NoticeService {
         Notice notice = noticeRepository.findById(noticeId)
                 .orElseThrow(() -> new RuntimeException("공지사항이 존재하지 않습니다."));
 
-
-
         // SaveNotice 엔티티 생성 및 저장
         SaveNotice saveNotice = SaveNotice.builder()
                 .notice(notice)
@@ -211,6 +209,30 @@ public class NoticeService {
                 })
                 .collect(Collectors.toList());
     }
+
+
+
+    @Transactional
+    public void viewCount(Long noticeId) {
+        Long memberId = principalHandler.getUserIdFromPrincipal();
+
+        // member와 notice를 가져옵니다.
+        Member member = authRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new RuntimeException("공지사항이 존재하지 않습니다."));
+
+        // viewCount를 1 증가시킵니다.
+        notice.setViewCount(notice.getViewCount() + 1);
+        noticeRepository.save(notice);
+
+        // NoticeView에서 해당 member와 notice의 데이터를 찾아 readAt을 true로 설정합니다.
+        NoticeView noticeView = noticeViewRepository.findByNoticeAndMember(notice, member)
+                .orElseThrow(() -> new RuntimeException("조회 기록이 존재하지 않습니다."));
+        noticeView.setReadAt(true);
+        noticeViewRepository.save(noticeView);
+    }
+
 
 
 

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -9,14 +9,8 @@ import sopt.univoice.domain.auth.PrincipalHandler;
 import sopt.univoice.domain.auth.repository.AuthRepository;
 import sopt.univoice.domain.notice.dto.NoticeCreateRequest;
 import sopt.univoice.domain.notice.dto.NoticeSaveDTO;
-import sopt.univoice.domain.notice.entity.Notice;
-import sopt.univoice.domain.notice.entity.NoticeImage;
-import sopt.univoice.domain.notice.entity.NoticeLike;
-import sopt.univoice.domain.notice.entity.SaveNotice;
-import sopt.univoice.domain.notice.repository.NoticeImageRepository;
-import sopt.univoice.domain.notice.repository.NoticeLikeRepository;
-import sopt.univoice.domain.notice.repository.NoticeRepository;
-import sopt.univoice.domain.notice.repository.SaveNoticeRepository;
+import sopt.univoice.domain.notice.entity.*;
+import sopt.univoice.domain.notice.repository.*;
 import sopt.univoice.domain.user.entity.Member;
 import sopt.univoice.domain.affiliation.entity.Role;
 import sopt.univoice.infra.common.exception.UnauthorizedException;
@@ -41,6 +35,7 @@ public class NoticeService {
     private final OpenAiService openAiService;
     private final NoticeLikeRepository noticeLikeRepository;
     private final SaveNoticeRepository saveNoticeRepository;
+    private final NoticeViewRepository noticeViewRepository;
 
     @Transactional
     public void createPost(NoticeCreateRequest noticeCreateRequest) {
@@ -88,6 +83,20 @@ public class NoticeService {
             noticeImageRepository.save(noticeImage);
             System.out.println("NoticeImage saved successfully with file name: " + fileName);
         }
+
+        // NoticeView 엔티티 생성 및 저장
+        String universityName = member.getUniversityName();
+        List<Member> universityMembers = authRepository.findByUniversityName(universityName);
+
+        for (Member universityMember : universityMembers) {
+            NoticeView noticeView = NoticeView.builder()
+                    .notice(notice)
+                    .member(universityMember)
+                    .readAt(false)
+                    .build();
+            noticeViewRepository.save(noticeView);
+        }
+
     }
 
     private String storeFile(MultipartFile file) {

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import sopt.univoice.domain.affiliation.entity.Affiliation;
 import sopt.univoice.domain.auth.PrincipalHandler;
 import sopt.univoice.domain.auth.repository.AuthRepository;
 import sopt.univoice.domain.notice.dto.*;
@@ -436,6 +437,36 @@ public class NoticeService {
         )).collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public NoticeDetailResponseDTO getNoticeById(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+                .orElseThrow(() -> new RuntimeException("공지사항이 존재하지 않습니다."));
+
+        // notice의 member_id를 통해 Member를 가져옵니다.
+        Member member = notice.getMember();
+
+        // Member의 affiliation_id를 통해 Affiliation을 가져옵니다.
+        Affiliation affiliation = member.getAffiliation();
+
+        // Affiliation의 affiliation 값을 가져옵니다.
+        String writeAffiliation = affiliation.getAffiliation();
+
+        return new NoticeDetailResponseDTO(
+                notice.getId(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getNoticeLike(),
+                notice.getViewCount(),
+                notice.getTarget(),
+                notice.getStartTime(),
+                notice.getEndTime(),
+                notice.getCategory(),
+                notice.getContentSummary(),
+                notice.getMember().getId(),
+                writeAffiliation, // 추가된 부분
+                notice.getNoticeImages().stream().map(NoticeImage::getNoticeImage).collect(Collectors.toList())
+        );
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -403,4 +403,35 @@ public class NoticeService {
 
 
 
+
+
+    @Transactional
+    public List<QuickQueryNoticeDTO> getQuickNoticeByUserUniversity(String affiliation) {
+        Long memberId = principalHandler.getUserIdFromPrincipal();
+
+        Member member = authRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid member ID"));
+
+        String universityName = member.getUniversityName();
+
+        List<Notice> notices = noticeRepository.findByMemberUniversityNameAndAffiliationAffiliation(universityName, affiliation);
+
+        List<Notice> filteredNotices = notices.stream()
+                .filter(notice -> notice.getNoticeViews().stream()
+                        .anyMatch(noticeView -> noticeView.getMember().getId().equals(memberId) && !noticeView.isReadAt()))
+                .collect(Collectors.toList());
+
+        return filteredNotices.stream().map(notice -> new QuickQueryNoticeDTO(
+                notice.getId(),
+                notice.getStartTime(),
+                notice.getEndTime(),
+                notice.getTitle(),
+                notice.getNoticeLike(),
+                (long) notice.getSaveNotices().size(),
+                notice.getCategory()
+        )).collect(Collectors.toList());
+    }
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -317,4 +317,55 @@ public class NoticeService {
 
         return new GetUniversityNoticesResponseDTO(quickScans, noticeResponseDTOs);
     }
+
+
+
+
+
+
+    @Transactional
+    public GetUniversityNoticesResponseDTO getCollegeDepartmentNoticeByUserUniversity() {
+        Long memberId = principalHandler.getUserIdFromPrincipal();
+
+        Member member = authRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid member ID"));
+
+        String universityName = member.getUniversityName();
+        String collegeDepartmentName = member.getCollegeDepartmentName();
+        String departmentName = member.getDepartmentName();
+
+        long universityNameCount = noticeRepository.countByMemberUniversityNameAndMemberAffiliationAffiliation(universityName, "총학생회");
+        long collegeDepartmentCount = noticeRepository.countByMemberCollegeDepartmentNameAndMemberAffiliationAffiliation(collegeDepartmentName, "단과대학학생회");
+        long departmentCount = noticeRepository.countByMemberDepartmentNameAndMemberAffiliationAffiliation(departmentName, "과학생회");
+
+        List<Notice> universityNotices = noticeRepository.findByMemberUniversityNameAndMemberAffiliationAffiliation(universityName, "단과대학학생회");
+
+        List<NoticeResponseDTO> noticeResponseDTOs = universityNotices.stream().map(notice -> new NoticeResponseDTO(
+                notice.getId(),
+                notice.getStartTime(),
+                notice.getEndTime(),
+                notice.getTitle(),
+                notice.getNoticeLike(),
+                (long) notice.getSaveNotices().size(),
+                notice.getCategory()
+        )).collect(Collectors.toList());
+
+        QuickScanResponseDTO quickScans = new QuickScanResponseDTO(
+                universityName,
+                universityNameCount,
+                collegeDepartmentName,
+                collegeDepartmentCount,
+                departmentName,
+                departmentCount
+        );
+
+        return new GetUniversityNoticesResponseDTO(quickScans, noticeResponseDTOs);
+    }
+
+
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -416,6 +416,9 @@ public class NoticeService {
 
         List<Notice> notices = noticeRepository.findByMemberUniversityNameAndAffiliationAffiliation(universityName, affiliation);
 
+        System.out.println("Notices: " + notices);
+
+
         List<Notice> filteredNotices = notices.stream()
                 .filter(notice -> notice.getNoticeViews().stream()
                         .anyMatch(noticeView -> noticeView.getMember().getId().equals(memberId) && !noticeView.isReadAt()))

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -35,11 +35,15 @@ public class NoticeService {
     @Transactional
     public void createPost(NoticeCreateRequest noticeCreateRequest) {
         Long memberId = principalHandler.getUserIdFromPrincipal();
+        System.out.println("Authenticated Member ID: " + memberId);
         Member member = authRepository.findById(memberId)
                 .orElseThrow(() -> new RuntimeException("회원이 존재하지 않습니다."));
+        System.out.println("Member Role: " + member.getAffiliation().getRole());
+
 
         // 사용자 권한 확인
         if (member.getAffiliation().getRole() != Role.APPROVEADMIN) {
+            System.out.println("User does not have APPROVEADMIN role");
             throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
         }
 
@@ -47,12 +51,13 @@ public class NoticeService {
         Notice notice = Notice.builder()
                 .title(noticeCreateRequest.getTitle())
                 .content(noticeCreateRequest.getContent())
-                .target(noticeCreateRequest.getTarget().orElse(null))
-                .startTime(noticeCreateRequest.getStartTime().orElse(null))
-                .endTime(noticeCreateRequest.getEndTime().orElse(null))
+                .target(noticeCreateRequest.getTarget())
+                .startTime(noticeCreateRequest.getStartTime())
+                .endTime(noticeCreateRequest.getEndTime())
                 .member(member)
                 .build();
         noticeRepository.save(notice);
+        System.out.println("Notice saved successfully with ID: " + notice.getId());
 
         // NoticeImage 엔티티 생성 및 저장
         for (MultipartFile file : noticeCreateRequest.getStudentCardImages()) {
@@ -62,6 +67,7 @@ public class NoticeService {
                     .noticeImage(fileName)
                     .build();
             noticeImageRepository.save(noticeImage);
+            System.out.println("NoticeImage saved successfully with file name: " + fileName);
         }
     }
 

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -66,6 +66,7 @@ public class NoticeService {
                 .endTime(noticeCreateRequest.getEndTime())
                 .member(member)
                 .contentSummary(summarizedContent)
+                .category("공지사항")  // category 값을 '공지사항'으로 설정
                 .build();
         noticeRepository.save(notice);
         System.out.println("Notice saved successfully with ID: " + notice.getId());

--- a/src/main/java/sopt/univoice/domain/university/entity/CollegeDepartment.java
+++ b/src/main/java/sopt/univoice/domain/university/entity/CollegeDepartment.java
@@ -1,4 +1,0 @@
-package sopt.univoice.domain.university.entity;
-
-public class CollegeDepartment {
-}

--- a/src/main/java/sopt/univoice/domain/university/entity/Department.java
+++ b/src/main/java/sopt/univoice/domain/university/entity/Department.java
@@ -1,4 +1,0 @@
-package sopt.univoice.domain.university.entity;
-
-public class Department {
-}

--- a/src/main/java/sopt/univoice/domain/university/entity/University.java
+++ b/src/main/java/sopt/univoice/domain/university/entity/University.java
@@ -1,4 +1,0 @@
-package sopt.univoice.domain.university.entity;
-
-public class University {
-}

--- a/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
+++ b/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
@@ -9,7 +9,7 @@ import sopt.univoice.domain.universityData.service.UniversityDataService;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api1/universityData")
+@RequestMapping("/api/v1/universityData")
 @RequiredArgsConstructor
 public class UniversityDataController {
 

--- a/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
+++ b/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
@@ -1,0 +1,26 @@
+package sopt.univoice.domain.universityData.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import sopt.univoice.domain.universityData.service.UniversityDataService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api1/universityData")
+@RequiredArgsConstructor
+public class UniversityDataController {
+
+    private final UniversityDataService universityDataService;
+
+    @GetMapping("/university")
+    public List<String> getAllUniversityNames() {
+        return universityDataService.getAllUniversityNames();
+    }
+
+
+
+
+}

--- a/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
+++ b/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
@@ -4,8 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import sopt.univoice.domain.universityData.dto.UniversityNameRequest;
 import sopt.univoice.domain.universityData.service.UniversityDataService;
 import sopt.univoice.infra.common.dto.SuccessMessage;
 import sopt.univoice.infra.common.dto.SuccessStatusResponse;
@@ -25,6 +27,17 @@ public class UniversityDataController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessStatusResponse.of(SuccessMessage.UNIVERSITY_GET_SUCCESS, universityNames));
     }
+
+
+    @GetMapping("/department")
+    public ResponseEntity<SuccessStatusResponse<List<String>>> getDepartmentNamesByUniversity(@RequestBody UniversityNameRequest universityNameRequest) {
+        List<String> departmentNames = universityDataService.getDepartmentNamesByUniversity(universityNameRequest.getUniversityName());
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.UNIVERSITY_GET_SUCCESS, departmentNames));
+    }
+
+
+
 
 
 }

--- a/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
+++ b/src/main/java/sopt/univoice/domain/universityData/controller/UniversityDataController.java
@@ -1,10 +1,14 @@
 package sopt.univoice.domain.universityData.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import sopt.univoice.domain.universityData.service.UniversityDataService;
+import sopt.univoice.infra.common.dto.SuccessMessage;
+import sopt.univoice.infra.common.dto.SuccessStatusResponse;
 
 import java.util.List;
 
@@ -16,11 +20,11 @@ public class UniversityDataController {
     private final UniversityDataService universityDataService;
 
     @GetMapping("/university")
-    public List<String> getAllUniversityNames() {
-        return universityDataService.getAllUniversityNames();
+    public ResponseEntity<SuccessStatusResponse<List<String>>> getAllUniversityNames() {
+        List<String> universityNames = universityDataService.getAllUniversityNames();
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessStatusResponse.of(SuccessMessage.UNIVERSITY_GET_SUCCESS, universityNames));
     }
-
-
 
 
 }

--- a/src/main/java/sopt/univoice/domain/universityData/dto/UniversityNameRequest.java
+++ b/src/main/java/sopt/univoice/domain/universityData/dto/UniversityNameRequest.java
@@ -1,0 +1,10 @@
+package sopt.univoice.domain.universityData.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UniversityNameRequest {
+    private String universityName;
+}

--- a/src/main/java/sopt/univoice/domain/universityData/entity/CollegeDepartment.java
+++ b/src/main/java/sopt/univoice/domain/universityData/entity/CollegeDepartment.java
@@ -1,0 +1,29 @@
+package sopt.univoice.domain.universityData.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class CollegeDepartment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String collegeDepartmentName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_id")
+    private University university;
+
+
+    @OneToMany(mappedBy = "collegeDepartment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Department> departments;
+
+
+}

--- a/src/main/java/sopt/univoice/domain/universityData/entity/Department.java
+++ b/src/main/java/sopt/univoice/domain/universityData/entity/Department.java
@@ -26,4 +26,9 @@ public class Department {
     @JoinColumn(name = "university_id")
     private University university;
 
+
+    public Long getCollegeDepartmentId() {
+        return this.collegeDepartment.getId();
+    }
+
 }

--- a/src/main/java/sopt/univoice/domain/universityData/entity/Department.java
+++ b/src/main/java/sopt/univoice/domain/universityData/entity/Department.java
@@ -1,0 +1,29 @@
+package sopt.univoice.domain.universityData.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Department {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String departmentName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "college_department_id")
+    private CollegeDepartment collegeDepartment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_id")
+    private University university;
+
+}

--- a/src/main/java/sopt/univoice/domain/universityData/entity/University.java
+++ b/src/main/java/sopt/univoice/domain/universityData/entity/University.java
@@ -1,0 +1,24 @@
+package sopt.univoice.domain.universityData.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class University {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String universityName;
+
+    @OneToMany(mappedBy = "university")
+    private List<CollegeDepartment> collegeDepartments;
+
+
+}

--- a/src/main/java/sopt/univoice/domain/universityData/repository/DepartmentRepository.java
+++ b/src/main/java/sopt/univoice/domain/universityData/repository/DepartmentRepository.java
@@ -1,0 +1,10 @@
+package sopt.univoice.domain.universityData.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.universityData.entity.Department;
+
+import java.util.List;
+
+public interface DepartmentRepository extends JpaRepository<Department, Long> {
+    List<Department> findByUniversityId(Long universityId);
+}

--- a/src/main/java/sopt/univoice/domain/universityData/repository/DepartmentRepository.java
+++ b/src/main/java/sopt/univoice/domain/universityData/repository/DepartmentRepository.java
@@ -6,5 +6,6 @@ import sopt.univoice.domain.universityData.entity.Department;
 import java.util.List;
 
 public interface DepartmentRepository extends JpaRepository<Department, Long> {
+    List<Department> findByDepartmentName(String departmentName);
     List<Department> findByUniversityId(Long universityId);
 }

--- a/src/main/java/sopt/univoice/domain/universityData/repository/UniversityDataRepository.java
+++ b/src/main/java/sopt/univoice/domain/universityData/repository/UniversityDataRepository.java
@@ -1,0 +1,7 @@
+package sopt.univoice.domain.universityData.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import sopt.univoice.domain.universityData.entity.University;
+
+public interface UniversityDataRepository extends JpaRepository<University, Long> {
+}

--- a/src/main/java/sopt/univoice/domain/universityData/repository/UniversityDataRepository.java
+++ b/src/main/java/sopt/univoice/domain/universityData/repository/UniversityDataRepository.java
@@ -3,5 +3,9 @@ package sopt.univoice.domain.universityData.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.univoice.domain.universityData.entity.University;
 
+import java.util.Optional;
+
+
 public interface UniversityDataRepository extends JpaRepository<University, Long> {
+    Optional<University> findByUniversityName(String universityName);
 }

--- a/src/main/java/sopt/univoice/domain/universityData/service/UniversityDataService.java
+++ b/src/main/java/sopt/univoice/domain/universityData/service/UniversityDataService.java
@@ -1,0 +1,23 @@
+package sopt.univoice.domain.universityData.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import sopt.univoice.domain.universityData.entity.University;
+import sopt.univoice.domain.universityData.repository.UniversityDataRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UniversityDataService {
+
+    private final UniversityDataRepository universityDataRepository;
+
+    public List<String> getAllUniversityNames() {
+        List<University> universities = universityDataRepository.findAll();
+        return universities.stream()
+                .map(University::getUniversityName)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/sopt/univoice/domain/universityData/service/UniversityDataService.java
+++ b/src/main/java/sopt/univoice/domain/universityData/service/UniversityDataService.java
@@ -2,7 +2,9 @@ package sopt.univoice.domain.universityData.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import sopt.univoice.domain.universityData.entity.Department;
 import sopt.univoice.domain.universityData.entity.University;
+import sopt.univoice.domain.universityData.repository.DepartmentRepository;
 import sopt.univoice.domain.universityData.repository.UniversityDataRepository;
 
 import java.util.List;
@@ -13,6 +15,7 @@ import java.util.stream.Collectors;
 public class UniversityDataService {
 
     private final UniversityDataRepository universityDataRepository;
+    private final DepartmentRepository departmentRepository;
 
     public List<String> getAllUniversityNames() {
         List<University> universities = universityDataRepository.findAll();
@@ -20,4 +23,20 @@ public class UniversityDataService {
                 .map(University::getUniversityName)
                 .collect(Collectors.toList());
     }
+
+
+    public List<String> getDepartmentNamesByUniversity(String universityName) {
+        University university = universityDataRepository.findByUniversityName(universityName)
+                .orElseThrow(() -> new IllegalArgumentException("University not found: " + universityName));
+
+        List<Department> departments = departmentRepository.findByUniversityId(university.getId());
+        return departments.stream()
+                .map(Department::getDepartmentName)
+                .collect(Collectors.toList());
+    }
+
+
+
+
+
 }

--- a/src/main/java/sopt/univoice/domain/user/controller/UserController.java
+++ b/src/main/java/sopt/univoice/domain/user/controller/UserController.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.user.controller;
+
+public class UserController {
+}

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -4,10 +4,13 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import sopt.univoice.domain.affiliation.entity.Affiliation;
 import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.infra.persistence.BaseTimeEntity;
 
+import java.util.Collection;
 import java.util.List;
 
 
@@ -58,6 +61,10 @@ public class Member extends BaseTimeEntity {
         this.collegeDepartmentName = collegeDepartmentName;
         this.departmentName = departmentName;
         this.affiliation = affiliation;
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority( affiliation.getRole().name()));
     }
 
 }

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -1,0 +1,43 @@
+package sopt.univoice.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import sopt.univoice.domain.affiliation.entity.Affiliation;
+import sopt.univoice.infra.persistence.BaseTimeEntity;
+
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private  Long admissionNumber;
+
+    private String name;
+
+    private String studentNumber;
+
+    private String email;
+
+    private String password;
+
+    private String studentCardImage;
+
+    private String  universityName;
+
+    private String collegeDepartmentName;
+
+    private String departmentName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "affiliation_id")
+    private Affiliation affiliation;
+
+
+
+
+}

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -53,14 +53,15 @@ public class Member extends BaseTimeEntity {
 
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NoticeLike> noticeLikes; // Member와 NoticeLike의 1:N 관계
+    private List<NoticeLike> noticeLikes;
 
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<SaveNotice> saveNotices; // Member와 NoticeLike의 1:N 관계
+    private List<SaveNotice> saveNotices;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NoticeView> noticeView; // Member와 NoticeLike의 1:N 관계
+    private List<NoticeView> noticeView;
+
 
     @Builder
     public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage,

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -39,17 +39,18 @@ public class Member extends BaseTimeEntity {
     private Affiliation affiliation;
 
     @Builder
-    public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage,String collegeDepartmentName, String universityName, String departmentName) {
+    public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage,
+                  String universityName, String collegeDepartmentName, String departmentName, Affiliation affiliation) {
         this.admissionNumber = admissionNumber;
         this.name = name;
         this.studentNumber = studentNumber;
         this.email = email;
         this.password = password;
         this.studentCardImage = studentCardImage;
-        this.collegeDepartmentName=collegeDepartmentName;
         this.universityName = universityName;
+        this.collegeDepartmentName = collegeDepartmentName;
         this.departmentName = departmentName;
+        this.affiliation = affiliation;
     }
-
 
 }

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -8,6 +8,9 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import sopt.univoice.domain.affiliation.entity.Affiliation;
 import sopt.univoice.domain.notice.entity.Notice;
+import sopt.univoice.domain.notice.entity.NoticeLike;
+import sopt.univoice.domain.notice.entity.NoticeView;
+import sopt.univoice.domain.notice.entity.SaveNotice;
 import sopt.univoice.infra.persistence.BaseTimeEntity;
 
 import java.util.Collection;
@@ -47,6 +50,17 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Notice> notices;
+
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoticeLike> noticeLikes; // Member와 NoticeLike의 1:N 관계
+
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SaveNotice> saveNotices; // Member와 NoticeLike의 1:N 관계
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<NoticeView> noticeView; // Member와 NoticeLike의 1:N 관계
 
     @Builder
     public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage,

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -39,13 +39,14 @@ public class Member extends BaseTimeEntity {
     private Affiliation affiliation;
 
     @Builder
-    public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage, String universityName, String departmentName) {
+    public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage,String collegeDepartmentName, String universityName, String departmentName) {
         this.admissionNumber = admissionNumber;
         this.name = name;
         this.studentNumber = studentNumber;
         this.email = email;
         this.password = password;
         this.studentCardImage = studentCardImage;
+        this.collegeDepartmentName=collegeDepartmentName;
         this.universityName = universityName;
         this.departmentName = departmentName;
     }

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -1,6 +1,7 @@
 package sopt.univoice.domain.user.entity;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.affiliation.entity.Affiliation;
@@ -37,7 +38,17 @@ public class Member extends BaseTimeEntity {
     @JoinColumn(name = "affiliation_id")
     private Affiliation affiliation;
 
-
+    @Builder
+    public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage, String universityName, String departmentName) {
+        this.admissionNumber = admissionNumber;
+        this.name = name;
+        this.studentNumber = studentNumber;
+        this.email = email;
+        this.password = password;
+        this.studentCardImage = studentCardImage;
+        this.universityName = universityName;
+        this.departmentName = departmentName;
+    }
 
 
 }

--- a/src/main/java/sopt/univoice/domain/user/entity/Member.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/Member.java
@@ -5,7 +5,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import sopt.univoice.domain.affiliation.entity.Affiliation;
+import sopt.univoice.domain.notice.entity.Notice;
 import sopt.univoice.infra.persistence.BaseTimeEntity;
+
+import java.util.List;
 
 
 @Entity
@@ -37,6 +40,10 @@ public class Member extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "affiliation_id")
     private Affiliation affiliation;
+
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Notice> notices;
 
     @Builder
     public Member(Long admissionNumber, String name, String studentNumber, String email, String password, String studentCardImage,

--- a/src/main/java/sopt/univoice/domain/user/entity/User.java
+++ b/src/main/java/sopt/univoice/domain/user/entity/User.java
@@ -1,4 +1,0 @@
-package sopt.univoice.domain.user.entity;
-
-public class User {
-}

--- a/src/main/java/sopt/univoice/domain/user/repository/UserRepositroy.java
+++ b/src/main/java/sopt/univoice/domain/user/repository/UserRepositroy.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.user.repository;
+
+public interface UserRepositroy {
+}

--- a/src/main/java/sopt/univoice/domain/user/service/UserService.java
+++ b/src/main/java/sopt/univoice/domain/user/service/UserService.java
@@ -1,0 +1,4 @@
+package sopt.univoice.domain.user.service;
+
+public class UserService {
+}

--- a/src/main/java/sopt/univoice/infra/common/dto/ErrorResponse.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/ErrorResponse.java
@@ -1,0 +1,15 @@
+package sopt.univoice.infra.common.dto;
+
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+
+public record ErrorResponse(
+        int status,
+        String message
+) {
+    public static ErrorResponse of(int status, String message) {
+        return new ErrorResponse(status, message);
+    }
+    public static ErrorResponse of(ErrorMessage errorMessage) {
+        return new ErrorResponse(errorMessage.getStatus(), errorMessage.getMessage());
+    }
+}

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum SuccessMessage {
 
-    UNIVERSITY_GET_SUCCESS(HttpStatus.CREATED.value(),"대학교이름 조회에 성공하였습니다."),
+    UNIVERSITY_GET_SUCCESS(HttpStatus.OK.value(),"대학교이름 조회에 성공하였습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -16,7 +16,8 @@ public enum SuccessMessage {
     CREATE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지작성에 성공하였습니다."),
     LIKE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 좋아요에 성공하였습니다."),
     LIKE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 좋아요 취소에 성공하였습니다."),
-
+    SAVE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장에 성공하였습니다."),
+    SAVE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 취소에 성공하였습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -19,6 +19,7 @@ public enum SuccessMessage {
     SAVE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장에 성공하였습니다."),
     SAVE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 취소에 성공하였습니다."),
     SAVE_ALL_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 리스트 조회에 성공하였습니다."),
+    VIEW_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 조회 체크에 성공하였습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -10,6 +10,8 @@ public enum SuccessMessage {
 
     UNIVERSITY_GET_SUCCESS(HttpStatus.OK.value(),"대학교이름 조회에 성공하였습니다."),
     DEPARTMENT_GET_SUCCESS(HttpStatus.OK.value(),"대학교이름을 통해 학과 조회에 성공하였습니다."),
+    EMAIL_DUPLICATE(HttpStatus.OK.value(),"이미 해당 아이디를 사용자가 사용중입니다. "),
+    EMAIL_AVAILABLE(HttpStatus.OK.value(),"사용가능한 아이디입니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -1,0 +1,15 @@
+package sopt.univoice.infra.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+
+    UNIVERSITY_GET_SUCCESS(HttpStatus.CREATED.value(),"대학교이름 조회에 성공하였습니다."),
+    ;
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -24,7 +24,8 @@ public enum SuccessMessage {
     GET_ALL_UNIVERSITY_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"총학생회 공지 조회에 성공하였습니다."),
     GET_ALL_COLLEGE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"단과대학 학생회 공지 조회에 성공하였습니다."),
     GET_ALL_DEPARTMENT_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"학과 학생회 공지 조회에 성공하였습니다."),
-    GET_QUICK_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"퀵스캔 공지 조회에 성공하였습니다.")
+    GET_QUICK_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"퀵스캔 공지 조회에 성공하였습니다."),
+    GET_Detail_NOTICE_SUCCESS(HttpStatus.OK.value(),"개별 공지 조회에 성공하였습니다.")
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -18,6 +18,7 @@ public enum SuccessMessage {
     LIKE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 좋아요 취소에 성공하였습니다."),
     SAVE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장에 성공하였습니다."),
     SAVE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 취소에 성공하였습니다."),
+    SAVE_ALL_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 리스트 조회에 성공하였습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -13,6 +13,7 @@ public enum SuccessMessage {
     EMAIL_DUPLICATE(HttpStatus.OK.value(),"이미 해당 아이디를 사용자가 사용중입니다. "),
     EMAIL_AVAILABLE(HttpStatus.OK.value(),"사용가능한 아이디입니다."),
     SIGNUP_SUCCESS(HttpStatus.CREATED.value(),"회원가입에 성공하였습니다."),
+    CREATE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지작성에 성공하였습니다."),
 
     ;
     private final int status;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -23,7 +23,8 @@ public enum SuccessMessage {
     GET_ALL_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"전체 공지 조회에 성공하였습니다."),
     GET_ALL_UNIVERSITY_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"총학생회 공지 조회에 성공하였습니다."),
     GET_ALL_COLLEGE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"단과대학 학생회 공지 조회에 성공하였습니다."),
-    GET_ALL_DEPARTMENT_SUCCESS(HttpStatus.CREATED.value(),"학과 학생회 공지 조회에 성공하였습니다."),
+    GET_ALL_DEPARTMENT_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"학과 학생회 공지 조회에 성공하였습니다."),
+    GET_QUICK_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"퀵스캔 공지 조회에 성공하였습니다.")
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -20,6 +20,10 @@ public enum SuccessMessage {
     SAVE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 취소에 성공하였습니다."),
     SAVE_ALL_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 저장 리스트 조회에 성공하였습니다."),
     VIEW_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 조회 체크에 성공하였습니다."),
+    GET_ALL_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"전체 공지 조회에 성공하였습니다."),
+    GET_ALL_UNIVERSITY_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"총학생회 공지 조회에 성공하였습니다."),
+    GET_ALL_COLLEGE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"단과대학 학생회 공지 조회에 성공하였습니다."),
+    GET_ALL_DEPARTMENT_SUCCESS(HttpStatus.CREATED.value(),"학과 학생회 공지 조회에 성공하였습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
 
     UNIVERSITY_GET_SUCCESS(HttpStatus.OK.value(),"대학교이름 조회에 성공하였습니다."),
+    DEPARTMENT_GET_SUCCESS(HttpStatus.OK.value(),"대학교이름을 통해 학과 조회에 성공하였습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -12,6 +12,8 @@ public enum SuccessMessage {
     DEPARTMENT_GET_SUCCESS(HttpStatus.OK.value(),"대학교이름을 통해 학과 조회에 성공하였습니다."),
     EMAIL_DUPLICATE(HttpStatus.OK.value(),"이미 해당 아이디를 사용자가 사용중입니다. "),
     EMAIL_AVAILABLE(HttpStatus.OK.value(),"사용가능한 아이디입니다."),
+    SIGNUP_SUCCESS(HttpStatus.CREATED.value(),"회원가입에 성공하였습니다."),
+
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessMessage.java
@@ -14,6 +14,8 @@ public enum SuccessMessage {
     EMAIL_AVAILABLE(HttpStatus.OK.value(),"사용가능한 아이디입니다."),
     SIGNUP_SUCCESS(HttpStatus.CREATED.value(),"회원가입에 성공하였습니다."),
     CREATE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지작성에 성공하였습니다."),
+    LIKE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 좋아요에 성공하였습니다."),
+    LIKE_CANCLE_NOTICE_SUCCESS(HttpStatus.CREATED.value(),"공지 좋아요 취소에 성공하였습니다."),
 
     ;
     private final int status;

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessStatusResponse.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessStatusResponse.java
@@ -1,0 +1,12 @@
+package sopt.univoice.infra.common.dto;
+
+public record SuccessStatusResponse(
+        int status,
+        String message
+) {
+
+    public static SuccessStatusResponse of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage());
+    }
+
+}

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessStatusResponse.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessStatusResponse.java
@@ -1,12 +1,12 @@
 package sopt.univoice.infra.common.dto;
 
-public record SuccessStatusResponse(
+public record SuccessStatusResponse<T>(
         int status,
-        String message
+        String message,
+        T data
 ) {
 
-    public static SuccessStatusResponse of(SuccessMessage successMessage) {
-        return new SuccessStatusResponse(successMessage.getStatus(), successMessage.getMessage());
+    public static <T> SuccessStatusResponse<T> of(SuccessMessage successMessage, T data) {
+        return new SuccessStatusResponse<>(successMessage.getStatus(), successMessage.getMessage(), data);
     }
-
 }

--- a/src/main/java/sopt/univoice/infra/common/dto/SuccessStatusResponse.java
+++ b/src/main/java/sopt/univoice/infra/common/dto/SuccessStatusResponse.java
@@ -9,4 +9,8 @@ public record SuccessStatusResponse<T>(
     public static <T> SuccessStatusResponse<T> of(SuccessMessage successMessage, T data) {
         return new SuccessStatusResponse<>(successMessage.getStatus(), successMessage.getMessage(), data);
     }
+    public static SuccessStatusResponse<Void> of(SuccessMessage successMessage) {
+        return new SuccessStatusResponse<>(successMessage.getStatus(), successMessage.getMessage(), null);
+    }
+
 }

--- a/src/main/java/sopt/univoice/infra/common/exception/BusinessException.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/BusinessException.java
@@ -1,0 +1,12 @@
+package sopt.univoice.infra.common.exception;
+
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+
+public class BusinessException extends RuntimeException {
+    private ErrorMessage errorMessage;
+
+    public BusinessException(ErrorMessage errorMessage) {
+        super(errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/sopt/univoice/infra/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import sopt.univoice.infra.common.dto.ErrorResponse;
+import sopt.univoice.infra.common.exception.message.BusinessException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -13,5 +14,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(EntityNotFoundException.class)
     protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(e.getErrorMessage()));
     }
 }

--- a/src/main/java/sopt/univoice/infra/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package sopt.univoice.infra.common.exception;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import sopt.univoice.infra.common.dto.ErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException.class)
+    protected ResponseEntity<ErrorResponse> handleEntityNotFoundException(EntityNotFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(), e.getMessage()));
+    }
+}

--- a/src/main/java/sopt/univoice/infra/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/GlobalExceptionHandler.java
@@ -20,4 +20,14 @@ public class GlobalExceptionHandler {
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(ErrorResponse.of(e.getErrorMessage()));
     }
+
+
+
+    @ExceptionHandler(UnauthorizedException.class)
+    protected ResponseEntity<ErrorResponse> handlerUnauthorizedException(UnauthorizedException e) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponse.of(e.getErrorMessage().getStatus(), e.getErrorMessage().getMessage()));
+    }
+
+
 }

--- a/src/main/java/sopt/univoice/infra/common/exception/NotFoundException.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/NotFoundException.java
@@ -1,5 +1,6 @@
 package sopt.univoice.infra.common.exception;
 
+import sopt.univoice.infra.common.exception.message.BusinessException;
 import sopt.univoice.infra.common.exception.message.ErrorMessage;
 
 public class NotFoundException extends BusinessException {

--- a/src/main/java/sopt/univoice/infra/common/exception/NotFoundException.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/NotFoundException.java
@@ -1,0 +1,9 @@
+package sopt.univoice.infra.common.exception;
+
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+
+public class NotFoundException extends BusinessException {
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/sopt/univoice/infra/common/exception/UnauthorizedException.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/UnauthorizedException.java
@@ -1,0 +1,10 @@
+package sopt.univoice.infra.common.exception;
+
+import sopt.univoice.infra.common.exception.message.BusinessException;
+import sopt.univoice.infra.common.exception.message.ErrorMessage;
+
+public class UnauthorizedException extends BusinessException {
+    public UnauthorizedException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/sopt/univoice/infra/common/exception/message/BusinessException.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/message/BusinessException.java
@@ -1,4 +1,4 @@
-package sopt.univoice.infra.common.exception;
+package sopt.univoice.infra.common.exception.message;
 
 import sopt.univoice.infra.common.exception.message.ErrorMessage;
 
@@ -9,4 +9,10 @@ public class BusinessException extends RuntimeException {
         super(errorMessage.getMessage());
         this.errorMessage = errorMessage;
     }
+
+
+    public ErrorMessage getErrorMessage() {
+        return errorMessage;
+    }
+
 }

--- a/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
@@ -1,0 +1,14 @@
+package sopt.univoice.infra.common.exception.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorMessage {
+    MEMBER_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
+    BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다.");
+    private final int status;
+    private final String message;
+}

--- a/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
     MEMBER_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
     BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
-    EMAIL_DUPLICATE(HttpStatus.NO_CONTENT.value(), "이미 사용중인 이메일 입니다.."),
+    EMAIL_DUPLICATE(HttpStatus.NO_CONTENT.value(), "이미 사용중인 이메일 입니다."),
+    JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorMessage {
     MEMBER_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 사용자가 존재하지 않습니다."),
-    BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다.");
+    BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
+    EMAIL_DUPLICATE(HttpStatus.NO_CONTENT.value(), "이미 사용중인 이메일 입니다.."),
+    ;
     private final int status;
     private final String message;
 }

--- a/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
+++ b/src/main/java/sopt/univoice/infra/common/exception/message/ErrorMessage.java
@@ -11,6 +11,7 @@ public enum ErrorMessage {
     BLOG_NOT_FOUND(HttpStatus.NO_CONTENT.value(), "ID에 해당하는 블로그가 존재하지 않습니다."),
     EMAIL_DUPLICATE(HttpStatus.NO_CONTENT.value(), "이미 사용중인 이메일 입니다."),
     JWT_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "사용자의 로그인 검증을 실패했습니다."),
+    APPROVEADMIN_UNAUTHORIZED_EXCEPTION(HttpStatus.UNAUTHORIZED.value(), "승인된 관리자의 로그인 검증을 실패했습니다."),
     ;
     private final int status;
     private final String message;

--- a/src/main/java/sopt/univoice/infra/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/sopt/univoice/infra/common/jwt/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
         // Claim에는 token 생성시간과 만료시간, 그리고 사용자 인증 정보가 들어간다.
         claims.put(USER_ID, authentication.getPrincipal());
         claims.put(ROLES, authentication.getAuthorities().stream()
-                .map(grantedAuthority -> grantedAuthority.getAuthority()) // 'ROLE_' 접두사 추가
+                .map(grantedAuthority -> grantedAuthority.getAuthority())
                 .collect(Collectors.toList()));
 
         //헤더 타입을 설정해주는 Header Param, Claim 을 이용한 정보를 대상으로 암호화하여 Jwt 토큰을 만들어 반환.

--- a/src/main/java/sopt/univoice/infra/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/sopt/univoice/infra/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package sopt.univoice.infra.common.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String USER_ID = "userId";
+
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14;
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+
+    //Authentication 객체로 AccessToken 발행
+    public String issueAccessToken(final Authentication authentication) {
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+
+    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenExpirationTime));      // 만료 시간
+
+        // Claim에는 token 생성시간과 만료시간, 그리고 사용자 인증 정보가 들어간다.
+        claims.put(USER_ID, authentication.getPrincipal());
+
+        //헤더 타입을 설정해주는 Header Param, Claim 을 이용한 정보를 대상으로 암호화하여 Jwt 토큰을 만들어 반환.
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용
+    }
+
+    //Token에서 Claim을 추출하는 과정에서 에러가 발생하면 Catch한 후 Validation을 진행
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    //Token의 Claim에서 USER_ID(userId) 값을 추출한다.
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(USER_ID).toString());
+    }
+}

--- a/src/main/java/sopt/univoice/infra/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/sopt/univoice/infra/common/jwt/JwtTokenProvider.java
@@ -49,7 +49,7 @@ public class JwtTokenProvider {
         // Claim에는 token 생성시간과 만료시간, 그리고 사용자 인증 정보가 들어간다.
         claims.put(USER_ID, authentication.getPrincipal());
         claims.put(ROLES, authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
+                .map(grantedAuthority -> grantedAuthority.getAuthority()) // 'ROLE_' 접두사 추가
                 .collect(Collectors.toList()));
 
         //헤더 타입을 설정해주는 Header Param, Claim 을 이용한 정보를 대상으로 암호화하여 Jwt 토큰을 만들어 반환.
@@ -69,14 +69,19 @@ public class JwtTokenProvider {
     public JwtValidationType validateToken(String token) {
         try {
             final Claims claims = getBody(token);
+            System.out.println("Token is valid(Provider): " + claims);
             return JwtValidationType.VALID_JWT;
         } catch (MalformedJwtException ex) {
+            System.out.println("Invalid JWT Token: " + ex.getMessage());
             return JwtValidationType.INVALID_JWT_TOKEN;
         } catch (ExpiredJwtException ex) {
+            System.out.println("Expired JWT Token: " + ex.getMessage());
             return JwtValidationType.EXPIRED_JWT_TOKEN;
         } catch (UnsupportedJwtException ex) {
+            System.out.println("Unsupported JWT Token: " + ex.getMessage());
             return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
         } catch (IllegalArgumentException ex) {
+            System.out.println("JWT Token is empty: " + ex.getMessage());
             return JwtValidationType.EMPTY_JWT;
         }
     }
@@ -99,6 +104,12 @@ public class JwtTokenProvider {
     public Collection<? extends GrantedAuthority> getAuthoritiesFromJwt(String token) {
         Claims claims = getBody(token);
         List<String> roles = claims.get(ROLES, List.class);
+        if (roles == null) {
+            System.out.println("역할 정보가 없어 빈 리스트 " );
+
+            return new ArrayList<>(); // 역할 정보가 없을 경우 빈 리스트 반환
+        }
+
         return roles.stream()
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());

--- a/src/main/java/sopt/univoice/infra/common/jwt/JwtValidationType.java
+++ b/src/main/java/sopt/univoice/infra/common/jwt/JwtValidationType.java
@@ -1,0 +1,10 @@
+package sopt.univoice.infra.common.jwt;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/src/main/java/sopt/univoice/infra/config/AwsConfig.java
+++ b/src/main/java/sopt/univoice/infra/config/AwsConfig.java
@@ -1,4 +1,4 @@
-package sopt.univoice.external;
+package sopt.univoice.infra.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/sopt/univoice/infra/config/FilterConfig.java
+++ b/src/main/java/sopt/univoice/infra/config/FilterConfig.java
@@ -1,0 +1,18 @@
+package sopt.univoice.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@Configuration
+public class FilterConfig {
+
+    @Bean
+    public CharacterEncodingFilter customCharacterEncodingFilter() {
+        CharacterEncodingFilter filter = new CharacterEncodingFilter();
+        filter.setEncoding("UTF-8");
+        filter.setForceEncoding(true);
+        return filter;
+    }
+}
+

--- a/src/main/java/sopt/univoice/infra/config/WebMvcConfig.java
+++ b/src/main/java/sopt/univoice/infra/config/WebMvcConfig.java
@@ -1,0 +1,17 @@
+package sopt.univoice.infra.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.UrlPathHelper;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        UrlPathHelper urlPathHelper = new UrlPathHelper();
+        urlPathHelper.setUrlDecode(false); // URL 디코딩 비활성화
+        configurer.setUrlPathHelper(urlPathHelper);
+    }
+}

--- a/src/main/java/sopt/univoice/infra/external/OpenAiService.java
+++ b/src/main/java/sopt/univoice/infra/external/OpenAiService.java
@@ -1,0 +1,56 @@
+package sopt.univoice.infra.external;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+
+@Service
+public class OpenAiService {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+
+    public String summarizeText(String text) throws IOException {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpPost httpPost = new HttpPost(OPENAI_API_URL);
+            httpPost.setHeader("Content-Type", "application/json");
+            httpPost.setHeader("Authorization", "Bearer " + openaiApiKey);
+
+            JSONObject json = new JSONObject();
+            json.put("model", "gpt-3.5-turbo");
+            JSONArray messages = new JSONArray();
+            messages.put(new JSONObject().put("role", "system").put("content", "You are an assistant that summarizes text in Korean to 150 characters or less."));
+            messages.put(new JSONObject().put("role", "user").put("content", "다음 텍스트를 150자 이내로 요약해 주세요: \"" + text + "\""));
+            json.put("messages", messages);
+            json.put("max_tokens", 200);
+            json.put("temperature", 0.7);
+
+            StringEntity entity = new StringEntity(json.toString());
+            httpPost.setEntity(entity);
+
+            try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+                String responseBody = EntityUtils.toString(response.getEntity());
+                System.out.println("API Response: " + responseBody);
+
+                JSONObject responseJson = new JSONObject(responseBody);
+
+                if (responseJson.has("choices")) {
+                    return responseJson.getJSONArray("choices").getJSONObject(0).getJSONObject("message").getString("content").trim();
+                } else {
+                    throw new IOException("API response does not contain 'choices' key.");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/sopt/univoice/infra/external/S3Service.java
+++ b/src/main/java/sopt/univoice/infra/external/S3Service.java
@@ -1,4 +1,5 @@
-package sopt.univoice.external;
+package sopt.univoice.infra.external;
+
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -7,6 +8,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import sopt.univoice.infra.config.AwsConfig;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -78,3 +80,4 @@ public class S3Service {
     }
 
 }
+


### PR DESCRIPTION


## 📌 관련 이슈
closed #8 

## 📝 작업 내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
<!-- 사진이 있는 경우 첨부해주세요 (선택)  -->


### NO2. 학교이름 리스트 반환
- 광운대학교과 서울과학기술 대학교의 데이터를 저장하였습니다.
- 노션에 생성 sql을 만들어 놓았으니 참조하시면 될꺼같습니다.
![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/9d47fb73-4da0-4d7d-bed3-7b3c8add5d1a)





### NO.3   해당 학교의 학과 이름 리스트로 반환
- 대학교이름을 입력 받아 해당 대학교가 운영중인 학과를 리스트로 반환하는 api입니다.
-  아래 Postman API 테스트는 광운대학교로 진행 한 결과입니다.
![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/318d1d5d-3b6f-47a8-a91d-807737675eb1)



### NO.4 아이디 중복확인
- 이미 해당 아이디로 가입한 사용자가 있는지 중복 확인하는 API입니다.
- 중복이 아닌 아이디인 경우 200코드와 성공 메시지를 중복인 경우에는 204 코드와 함께 이미 사용중이라는 메세지를 보냅니다.
![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/14bfa270-ac6e-4eb8-9981-ac5228542a2c)



### NO.5  회원가입 요청 후 slack에 전송
- 사용자가 회원가입 요청을 할시 사용자의 정보를 DB에 저장한뒤 슬렉에 해당 사용자의 정보를 메세지로 전송합니다.
- 처음 DB에 저장될시에는 승인 거절을 확인하기 위해 연결된 affliation테이블의role은 null로 저장이 됩니다.(해당 부분은 기획가 논의 후 추가할 예정, 우선은 affliation_id값 자체가 null)

![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/963c789b-dbf8-490a-a298-a54c57e8a575)
![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/36324d9e-2886-4ff1-959a-8b08459ec668)

![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/2ddf9d3d-7b0d-40b2-b9aa-7897a7010ef9)


### NO.6 Slack에서의 승인 응답 확인
- slack에서 승인, 거절에 대한 입력 값을 보내기 위해서는 https 프로토콜이 필요하여 배포 이후 테스트 해 볼 예정입니다.
![image](https://github.com/Team-UniVoice/UniVoice_Server/assets/105472863/f5d6312d-c01c-48c7-b0ec-bcffd139b13d)


## 💬리뷰 요구사항
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->

- NO.5,6  클라이언트와 붙이기 이전 개발시에는 slack과 연관된 토큰과 Url을 application.yml에 관리 하지 않고 최종 api 테스트가 끝난이후 숨길 예정입니다.
- NO.5  : 현재 회원가입 이후 승인,미승인을 구분하기 위한  affliation테이블의 role은 고려하지 않았습니다. 이후 기획과 논의후  로직을 수정할 예정입니다. 우선  affliation_id자체를 null로 저장하도록 구현했습니다.
-NO.6 API 테스트는 https 프로토콜을 사용하야하기 때문에 배포 이후 테스트할 예정입니다.
-  합숙 기간 논의 한 이후 수정한 이후 다시 PR을 올릴 예정입니다.






