### PR TITLE
[FIX] 로고 이미지 가져오는 로직 수정 

### DIFF
--- a/src/main/java/sopt/univoice/domain/affiliation/repository/AffiliationRepository.java
+++ b/src/main/java/sopt/univoice/domain/affiliation/repository/AffiliationRepository.java
@@ -5,5 +5,4 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import sopt.univoice.domain.affiliation.entity.Affiliation;
 
 public interface AffiliationRepository extends JpaRepository<Affiliation, Long> {
-    Affiliation findByAffiliationAndAffiliationUniversityName(String affiliation, String affiliationUniversityName);
 }

--- a/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
+++ b/src/main/java/sopt/univoice/domain/notice/service/NoticeService.java
@@ -350,19 +350,34 @@ public class NoticeService {
         String departmentLogoImage = null;
 
         // '총학생회'에 대한 로고 이미지 가져오기
-        Affiliation universityAffiliation = affiliationRepository.findByAffiliationAndAffiliationUniversityName("총학생회", universityName);
+        Affiliation universityAffiliation = universityNotices.stream()
+                                                .map(Notice::getMember)
+                                                .map(Member::getAffiliation)
+                                                .filter(a -> "총학생회".equals(a.getAffiliation()))
+                                                .findFirst()
+                                                .orElse(null);
         if (universityAffiliation != null) {
             universityLogoImage = universityAffiliation.getAffiliationLogoImage();
         }
 
         // '단과대학학생회'에 대한 로고 이미지 가져오기
-        Affiliation collegeAffiliation = affiliationRepository.findByAffiliationAndAffiliationUniversityName("단과대학학생회", universityName);
+        Affiliation collegeAffiliation = collegeNotices.stream()
+                                             .map(Notice::getMember)
+                                             .map(Member::getAffiliation)
+                                             .filter(a -> "단과대학학생회".equals(a.getAffiliation()))
+                                             .findFirst()
+                                             .orElse(null);
         if (collegeAffiliation != null) {
             collegeDepartmentLogoImage = collegeAffiliation.getAffiliationLogoImage();
         }
 
         // '과학생회'에 대한 로고 이미지 가져오기
-        Affiliation departmentAffiliation = affiliationRepository.findByAffiliationAndAffiliationUniversityName("과학생회", universityName);
+        Affiliation departmentAffiliation = departmentNotices.stream()
+                                                .map(Notice::getMember)
+                                                .map(Member::getAffiliation)
+                                                .filter(a -> "과학생회".equals(a.getAffiliation()))
+                                                .findFirst()
+                                                .orElse(null);
         if (departmentAffiliation != null) {
             departmentLogoImage = departmentAffiliation.getAffiliationLogoImage();
         }


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- `[FEAT]` : 새로운 기능 구현
- `[CHORE]` : 동작에 영향 없는 코드 or 변경 없는 변경 사항(주석 추가 등)
- `[ADD]` : Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 파일 생성
- `[DEL]` : 쓸모 없는 코드 삭제
- `[RENAME]` : 파일 명, 변수 명 수정
- `[FIX]` : 코드 수정, 버그/오류 해결
- `[DOCS]` : README나 WIKI 등의 문서 수정
- `[DEPLOY]`: 배포 관련
- `[REFACTOR]` : 전면 수정, 코드 리팩토링
- `[MERGE]`: 다른 브랜치와 병합
- `[TEST]`: 테스트 추가/수정
- `[HOTFIX]` : 급한 핫픽스
-->

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #58 
## 📝 작업 내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요 -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->
<!-- 사진이 있는 경우 첨부해주세요 (선택)  -->
- 총학생회, 단과대학학생회, 과학생회의 로고 이미지가 null로 들어오는 오류를 해결했습니다. 

## 💬리뷰 요구사항
<!-- Reviewers, Assignees, Labels 지정해주세요 -->
<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 공지를 작성한 사람의 소속에서 이미지를 가져오는 로직으로 일단 수정했는데 추후 이부분은 공지가 아무것도 안들어있을때의 경우를 대비해 수정해야할 것 같습니다 !
-> 일단 데모데이 플로우에서는 문제가 없으니 나중에 수정하게는 좋을 것 같습니다. 